### PR TITLE
Add HiveShell#executeScript

### DIFF
--- a/src/main/java/com/klarna/hiverunner/HiveShell.java
+++ b/src/main/java/com/klarna/hiverunner/HiveShell.java
@@ -68,7 +68,7 @@ public interface HiveShell {
      * <p/>
      * May only be called post #start()
      */
-    void executeScript(File file);
+    void execute(File file);
     
     /**
      * Executes a hive script. The script may contain multiple statements delimited by ';'.
@@ -76,21 +76,21 @@ public interface HiveShell {
      * <p/>
      * May only be called post #start()
      */
-    void executeScript(Path path);
+    void execute(Path path);
 
     /**
      * Executes a hive script. The script may contain multiple statements delimited by ';'
      * <p/>
      * May only be called post #start()
      */
-    void executeScript(Charset charset, File file);
+    void execute(Charset charset, File file);
     
     /**
      * Executes a hive script. The script may contain multiple statements delimited by ';'
      * <p/>
      * May only be called post #start()
      */
-    void executeScript(Charset charset, Path path);
+    void execute(Charset charset, Path path);
 
     /**
      * Start the shell. May only be called once. The test engine will by default call this method,

--- a/src/main/java/com/klarna/hiverunner/HiveShell.java
+++ b/src/main/java/com/klarna/hiverunner/HiveShell.java
@@ -63,6 +63,36 @@ public interface HiveShell {
     void execute(String script);
 
     /**
+     * Executes a hive script. The script may contain multiple statements delimited by ';'.
+     * Default charset will be used to read the given files.
+     * <p/>
+     * May only be called post #start()
+     */
+    void executeScript(File file);
+    
+    /**
+     * Executes a hive script. The script may contain multiple statements delimited by ';'.
+     * Default charset will be used to read the given files.
+     * <p/>
+     * May only be called post #start()
+     */
+    void executeScript(Path path);
+
+    /**
+     * Executes a hive script. The script may contain multiple statements delimited by ';'
+     * <p/>
+     * May only be called post #start()
+     */
+    void executeScript(Charset charset, File file);
+    
+    /**
+     * Executes a hive script. The script may contain multiple statements delimited by ';'
+     * <p/>
+     * May only be called post #start()
+     */
+    void executeScript(Charset charset, Path path);
+
+    /**
      * Start the shell. May only be called once. The test engine will by default call this method,
      * Set {@link com.klarna.hiverunner.annotations.HiveSQL#autoStart()} to false to explicitly control
      * when to start from the test case.

--- a/src/main/java/com/klarna/hiverunner/builder/HiveShellBase.java
+++ b/src/main/java/com/klarna/hiverunner/builder/HiveShellBase.java
@@ -101,25 +101,25 @@ class HiveShellBase implements HiveShell {
     }
 
     @Override
-    public void executeScript(File file) {
+    public void execute(File file) {
         assertStarted();
-        executeScript(Charset.defaultCharset(), file);
+        execute(Charset.defaultCharset(), file);
     }
 
     @Override
-    public void executeScript(Path path) {
+    public void execute(Path path) {
         assertStarted();
-        executeScript(Charset.defaultCharset(), path);
+        execute(Charset.defaultCharset(), path);
     }
 
     @Override
-    public void executeScript(Charset charset, File file) {
+    public void execute(Charset charset, File file) {
         assertStarted();
-        executeScript(charset, Paths.get(file.toURI()));
+        execute(charset, Paths.get(file.toURI()));
     }
 
     @Override
-    public void executeScript(Charset charset, Path path) {
+    public void execute(Charset charset, Path path) {
         assertStarted();
         assertFileExists(path);
         try {

--- a/src/main/java/com/klarna/hiverunner/builder/HiveShellBase.java
+++ b/src/main/java/com/klarna/hiverunner/builder/HiveShellBase.java
@@ -101,6 +101,35 @@ class HiveShellBase implements HiveShell {
     }
 
     @Override
+    public void executeScript(File file) {
+        assertStarted();
+        executeScript(Charset.defaultCharset(), file);
+    }
+
+    @Override
+    public void executeScript(Path path) {
+        assertStarted();
+        executeScript(Charset.defaultCharset(), path);
+    }
+
+    @Override
+    public void executeScript(Charset charset, File file) {
+        assertStarted();
+        executeScript(charset, Paths.get(file.toURI()));
+    }
+
+    @Override
+    public void executeScript(Charset charset, Path path) {
+        assertStarted();
+        assertFileExists(path);
+        try {
+            execute(new String(Files.readAllBytes(path), charset));
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Unable to read setup script file '" + path + "': " + e.getMessage(), e);
+        }
+    }
+
+    @Override
     public void start() {
         assertNotStarted();
         started = true;

--- a/src/test/java/com/klarna/hiverunner/ExecuteScriptIntegrationTest.java
+++ b/src/test/java/com/klarna/hiverunner/ExecuteScriptIntegrationTest.java
@@ -37,7 +37,7 @@ public class ExecuteScriptIntegrationTest {
       out.println("insert into table test_db.test_table values ('v1');");
     }
 
-    hiveShell.executeScript(file);
+    hiveShell.execute(file);
 
     List<String> result = hiveShell.executeQuery("select c0 from test_db.test_table");
 

--- a/src/test/java/com/klarna/hiverunner/ExecuteScriptIntegrationTest.java
+++ b/src/test/java/com/klarna/hiverunner/ExecuteScriptIntegrationTest.java
@@ -1,0 +1,47 @@
+package com.klarna.hiverunner;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+
+import com.klarna.hiverunner.annotations.HiveSQL;
+
+@RunWith(StandaloneHiveRunner.class)
+public class ExecuteScriptIntegrationTest {
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  @HiveSQL(files = {})
+  private HiveShell hiveShell;
+
+  @Test
+  public void testInsertRowWithExecuteScript() throws IOException {
+    File file = new File(temp.getRoot(), "insert_data.hql");
+
+    try (PrintStream out = new PrintStream(file)) {
+      out.println("create database test_db;");
+      out.println("create table test_db.test_table (");
+      out.println("  c0 string");
+      out.println(")");
+      out.println("stored as orc;");
+      out.println("insert into table test_db.test_table values ('v1');");
+    }
+
+    hiveShell.executeScript(file);
+
+    List<String> result = hiveShell.executeQuery("select c0 from test_db.test_table");
+
+    assertThat(result.size(), is(1));
+    assertThat(result.get(0), is("v1"));
+  }
+}

--- a/src/test/java/com/klarna/hiverunner/builder/HiveShellBaseTest.java
+++ b/src/test/java/com/klarna/hiverunner/builder/HiveShellBaseTest.java
@@ -82,7 +82,7 @@ public class HiveShellBaseTest {
 
       HiveShell shell = createHiveShell();
       shell.start();
-      shell.executeScript(file);
+      shell.execute(file);
 
       verify(container).executeScript(hql);
     }
@@ -96,7 +96,7 @@ public class HiveShellBaseTest {
 
       HiveShell shell = createHiveShell();
       shell.start();
-      shell.executeScript(UTF_8, file);
+      shell.execute(UTF_8, file);
 
       verify(container).executeScript(hql);
     }
@@ -110,7 +110,7 @@ public class HiveShellBaseTest {
 
       HiveShell shell = createHiveShell();
       shell.start();
-      shell.executeScript(Paths.get(file.toURI()));
+      shell.execute(Paths.get(file.toURI()));
 
       verify(container).executeScript(hql);
     }
@@ -124,7 +124,7 @@ public class HiveShellBaseTest {
 
       HiveShell shell = createHiveShell();
       shell.start();
-      shell.executeScript(UTF_8, Paths.get(file.toURI()));
+      shell.execute(UTF_8, Paths.get(file.toURI()));
 
       verify(container).executeScript(hql);
     }
@@ -135,7 +135,7 @@ public class HiveShellBaseTest {
 
       HiveShell shell = createHiveShell();
       shell.start();
-      shell.executeScript(UTF_8, Paths.get(file.toURI()));
+      shell.execute(UTF_8, Paths.get(file.toURI()));
     }
     
     @Test(expected = IllegalStateException.class)
@@ -143,7 +143,7 @@ public class HiveShellBaseTest {
       File file = new File(tempFolder.getRoot(), "script.hql");
       
       HiveShell shell = createHiveShell();
-      shell.executeScript(UTF_8, Paths.get(file.toURI()));
+      shell.execute(UTF_8, Paths.get(file.toURI()));
     }
 
     private HiveShell createHiveShell(String... keyValues) {

--- a/src/test/java/com/klarna/hiverunner/builder/HiveShellBaseTest.java
+++ b/src/test/java/com/klarna/hiverunner/builder/HiveShellBaseTest.java
@@ -1,12 +1,15 @@
 package com.klarna.hiverunner.builder;
 
+import static com.google.common.base.Charsets.UTF_8;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.io.Files;
 import com.klarna.hiverunner.HiveServerContainer;
 import com.klarna.hiverunner.HiveServerContext;
 import com.klarna.hiverunner.HiveShell;
 import org.apache.commons.collections.MapUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hive.service.cli.CLIService;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -14,6 +17,7 @@ import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -24,7 +28,7 @@ public class HiveShellBaseTest {
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
 
-
+    private HiveServerContainer container;
 
     @Test(expected = IllegalStateException.class)
     public void variableSubstitutionShouldBlowUpIfShellIsNotStarted() {
@@ -69,13 +73,86 @@ public class HiveShellBaseTest {
         shell.addSetupScripts(tempFolder.newFile("foo"));
     }
 
+    @Test
+    public void executeScriptFile() throws IOException {
+      String hql = "use default;";
+
+      File file = new File(tempFolder.getRoot(), "script.hql");
+      Files.write(hql, file, UTF_8);
+
+      HiveShell shell = createHiveShell();
+      shell.start();
+      shell.executeScript(file);
+
+      verify(container).executeScript(hql);
+    }
+
+    @Test
+    public void executeScriptCharsetFile() throws IOException {
+      String hql = "use default;";
+
+      File file = new File(tempFolder.getRoot(), "script.hql");
+      Files.write(hql, file, UTF_8);
+
+      HiveShell shell = createHiveShell();
+      shell.start();
+      shell.executeScript(UTF_8, file);
+
+      verify(container).executeScript(hql);
+    }
+    
+    @Test
+    public void executeScriptPath() throws IOException {
+      String hql = "use default;";
+
+      File file = new File(tempFolder.getRoot(), "script.hql");
+      Files.write(hql, file, UTF_8);
+
+      HiveShell shell = createHiveShell();
+      shell.start();
+      shell.executeScript(Paths.get(file.toURI()));
+
+      verify(container).executeScript(hql);
+    }
+
+    @Test
+    public void executeScriptCharsetPath() throws IOException {
+      String hql = "use default;";
+
+      File file = new File(tempFolder.getRoot(), "script.hql");
+      Files.write(hql, file, UTF_8);
+
+      HiveShell shell = createHiveShell();
+      shell.start();
+      shell.executeScript(UTF_8, Paths.get(file.toURI()));
+
+      verify(container).executeScript(hql);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void executeScriptFileNotExists() throws IOException {
+      File file = new File(tempFolder.getRoot(), "script.hql");
+
+      HiveShell shell = createHiveShell();
+      shell.start();
+      shell.executeScript(UTF_8, Paths.get(file.toURI()));
+    }
+    
+    @Test(expected = IllegalStateException.class)
+    public void executeScriptNotStarted() throws IOException {
+      File file = new File(tempFolder.getRoot(), "script.hql");
+      
+      HiveShell shell = createHiveShell();
+      shell.executeScript(UTF_8, Paths.get(file.toURI()));
+    }
+
     private HiveShell createHiveShell(String... keyValues) {
         Map<String, String> hiveConf = MapUtils.putAll(new HashMap(), keyValues);
         HiveConf conf = createHiveconf(hiveConf);
 
         CLIService client = Mockito.mock(CLIService.class);
 
-        HiveServerContainer container = Mockito.mock(HiveServerContainer.class);
+        container = Mockito.mock(HiveServerContainer.class);
         Mockito.when(container.getHiveConf()).thenReturn(conf);
         Mockito.when(container.getClient()).thenReturn(client);
 


### PR DESCRIPTION
Hi All,

After the addition of `HiveShell#insertInto`, our teams have started to use it and it's become clear there's a piece missing to help streamline the developer user experience. Once started, and data is inserted, you can only run scripts as a `String`, not as a `File`. So you have to read in your scripts and call `execute`. This PR provides convenience methods to take away that overhead, effectively mirroring the `addSetupScripts` functionality for 'after started'.

I know you mentioned in the previous PR about overhauling the pre/post start phases, so I hope this is in line with your thoughts/plans?