### PR TITLE
Support CLI-specific import file statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,11 @@ Future work and Limitations
 Change Log (From version 2.2.0 and onwards)
 ==============
 
-### __2.6.0-SNAPSHOT__
+### __2.6.1-SNAPSHOT__
+
+Support shell-specific `source` (`hive`) and ``!run`` (`beeline`) commands. (These commands allow to import and execute scripts in statements or scripts.)
+
+### __2.6.0__
 
 * Introduced command shell emulations to replicate different handling of full line comments in `hive` and `beeline` shells.
 Now strips full line comments for executed scripts to match the behaviour of the `hive -f` file option. 

--- a/src/main/java/com/klarna/hiverunner/CommandShellEmulation.java
+++ b/src/main/java/com/klarna/hiverunner/CommandShellEmulation.java
@@ -15,6 +15,8 @@
  */
 package com.klarna.hiverunner;
 
+import java.io.File;
+
 /**
  * Attempt to accurately emulate the behaviours (good and bad) of different Hive shells. Currently the {@code hive}
  * interactive shell (which HiveRunner uses) has an annoying issue where it blows up on some full line comments
@@ -31,6 +33,13 @@ public enum CommandShellEmulation {
     public boolean isImportFileStatement(String statement) {
       // case-insensitive
       return statement.trim().toLowerCase().startsWith(sourceCommand);
+    }
+
+    @Override
+    public File getImportFileFromStatement(String statement) {
+      // everything after 'source' (trimmed) is considered the filename
+      String filename = statement.trim().substring(sourceCommand.length()).trim();
+      return new File(filename);
     }
 
     @Override
@@ -54,6 +63,16 @@ public enum CommandShellEmulation {
     }
 
     @Override
+    public File getImportFileFromStatement(String statement) {
+      // filename cannot contain whitespace
+      String[] tokens = statement.trim().split(" ");
+      if (tokens.length == 2) {
+        return new File(tokens[1]);
+      }
+      throw new IllegalArgumentException("Cannot get file to import from '" + statement + "'");
+    }
+
+    @Override
     public String transformStatement(String statement) {
       return filterFullLineComments(statement);
     }
@@ -65,6 +84,8 @@ public enum CommandShellEmulation {
   };
 
   public abstract boolean isImportFileStatement(String statement);
+
+  public abstract File getImportFileFromStatement(String statement);
 
   public abstract String transformStatement(String statement);
 

--- a/src/main/java/com/klarna/hiverunner/CommandShellEmulation.java
+++ b/src/main/java/com/klarna/hiverunner/CommandShellEmulation.java
@@ -24,9 +24,13 @@ package com.klarna.hiverunner;
  */
 public enum CommandShellEmulation {
   HIVE_CLI {
+
+    private final String sourceCommand = "source";
+
     @Override
     public boolean isImportFileStatement(String statement) {
-      return statementStartsWithToken(statement, "source");
+      // case-insensitive
+      return statement.trim().toLowerCase().startsWith(sourceCommand);
     }
 
     @Override
@@ -40,9 +44,13 @@ public enum CommandShellEmulation {
     }
   },
   BEELINE {
+
+    private final String runCommand = "!run";
+
     @Override
     public boolean isImportFileStatement(String statement) {
-      return statementStartsWithToken(statement, "!run");
+      // case-sensitive
+      return statement.trim().startsWith(runCommand);
     }
 
     @Override
@@ -61,10 +69,6 @@ public enum CommandShellEmulation {
   public abstract String transformStatement(String statement);
 
   public abstract String transformScript(String script);
-
-  private static boolean statementStartsWithToken(String statement, String token) {
-    return statement.trim().toLowerCase().startsWith(token);
-  }
 
   private static String filterFullLineComments(String statement) {
     StringBuilder newStatement = new StringBuilder(statement.length());

--- a/src/main/java/com/klarna/hiverunner/CommandShellEmulation.java
+++ b/src/main/java/com/klarna/hiverunner/CommandShellEmulation.java
@@ -25,6 +25,11 @@ package com.klarna.hiverunner;
 public enum CommandShellEmulation {
   HIVE_CLI {
     @Override
+    public boolean isImportFileStatement(String statement) {
+      return statementStartsWithToken(statement, "source");
+    }
+
+    @Override
     public String transformStatement(String statement) {
       return statement;
     }
@@ -36,6 +41,11 @@ public enum CommandShellEmulation {
   },
   BEELINE {
     @Override
+    public boolean isImportFileStatement(String statement) {
+      return statementStartsWithToken(statement, "!run");
+    }
+
+    @Override
     public String transformStatement(String statement) {
       return filterFullLineComments(statement);
     }
@@ -46,9 +56,15 @@ public enum CommandShellEmulation {
     }
   };
 
+  public abstract boolean isImportFileStatement(String statement);
+
   public abstract String transformStatement(String statement);
 
   public abstract String transformScript(String script);
+
+  private static boolean statementStartsWithToken(String statement, String token) {
+    return statement.trim().toLowerCase().startsWith(token);
+  }
 
   private static String filterFullLineComments(String statement) {
     StringBuilder newStatement = new StringBuilder(statement.length());

--- a/src/main/java/com/klarna/hiverunner/HiveQueryLanguageStatement.java
+++ b/src/main/java/com/klarna/hiverunner/HiveQueryLanguageStatement.java
@@ -1,0 +1,18 @@
+package com.klarna.hiverunner;
+
+public class HiveQueryLanguageStatement {
+
+    public static HiveQueryLanguageStatement forStatementString(String statementString) {
+        return new HiveQueryLanguageStatement(statementString);
+    }
+
+    private final String statementString;
+
+    private HiveQueryLanguageStatement(String statementString) {
+        this.statementString = statementString;
+    }
+
+    public String getStatementString() {
+        return statementString;
+    }
+}

--- a/src/main/java/com/klarna/hiverunner/HiveQueryLanguageStatement.java
+++ b/src/main/java/com/klarna/hiverunner/HiveQueryLanguageStatement.java
@@ -3,7 +3,7 @@ package com.klarna.hiverunner;
 public class HiveQueryLanguageStatement {
 
     public static HiveQueryLanguageStatement forStatementString(String statementString) {
-        return new HiveQueryLanguageStatement(statementString);
+        return new HiveQueryLanguageStatement(statementString.trim());
     }
 
     private final String statementString;

--- a/src/main/java/com/klarna/hiverunner/HiveServerContainer.java
+++ b/src/main/java/com/klarna/hiverunner/HiveServerContainer.java
@@ -17,6 +17,7 @@
 package com.klarna.hiverunner;
 
 import com.google.common.base.Preconditions;
+import com.klarna.hiverunner.hql.HiveQueryLanguageStatement;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.tez.TezJobMonitor;

--- a/src/main/java/com/klarna/hiverunner/HiveServerContainer.java
+++ b/src/main/java/com/klarna/hiverunner/HiveServerContainer.java
@@ -107,9 +107,10 @@ public class HiveServerContainer {
         return context.getBaseDir();
     }
 
-    public List<Object[]> executeStatement(String hiveql) {
+    public List<Object[]> executeStatement(HiveQueryLanguageStatement hiveql) {
         try {
-            OperationHandle handle = client.executeStatement(sessionHandle, hiveql, new HashMap<String, String>());
+            OperationHandle handle = client.executeStatement(sessionHandle, hiveql.getStatementString(),
+                    new HashMap<String, String>());
             List<Object[]> resultSet = new ArrayList<>();
             if (handle.hasResultSet()) {
 
@@ -148,7 +149,7 @@ public class HiveServerContainer {
 
         try {
             // Reset to default schema
-            executeStatement("USE default");
+            executeStatement(HiveQueryLanguageStatement.forStatementString("USE default"));
         } catch (Throwable e) {
             LOGGER.warn("Failed to reset to default schema: " + e.getMessage() +
                     ". Turn on log level debug for stacktrace");
@@ -182,7 +183,7 @@ public class HiveServerContainer {
     }
 
     private void pingHiveServer() {
-        executeStatement("SHOW TABLES");
+        executeStatement(HiveQueryLanguageStatement.forStatementString("SHOW TABLES"));
     }
 
     public HiveConf getHiveConf() {

--- a/src/main/java/com/klarna/hiverunner/HiveServerContainer.java
+++ b/src/main/java/com/klarna/hiverunner/HiveServerContainer.java
@@ -17,7 +17,6 @@
 package com.klarna.hiverunner;
 
 import com.google.common.base.Preconditions;
-import com.klarna.hiverunner.hql.HiveQueryLanguageStatement;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.tez.TezJobMonitor;
@@ -108,10 +107,9 @@ public class HiveServerContainer {
         return context.getBaseDir();
     }
 
-    public List<Object[]> executeStatement(HiveQueryLanguageStatement hiveql) {
+    public List<Object[]> executeStatement(String hiveql) {
         try {
-            OperationHandle handle = client.executeStatement(sessionHandle, hiveql.getStatementString(),
-                    new HashMap<String, String>());
+            OperationHandle handle = client.executeStatement(sessionHandle, hiveql, new HashMap<String, String>());
             List<Object[]> resultSet = new ArrayList<>();
             if (handle.hasResultSet()) {
 
@@ -150,7 +148,7 @@ public class HiveServerContainer {
 
         try {
             // Reset to default schema
-            executeStatement(HiveQueryLanguageStatement.forStatementString("USE default"));
+            executeStatement("USE default");
         } catch (Throwable e) {
             LOGGER.warn("Failed to reset to default schema: " + e.getMessage() +
                     ". Turn on log level debug for stacktrace");
@@ -184,7 +182,7 @@ public class HiveServerContainer {
     }
 
     private void pingHiveServer() {
-        executeStatement(HiveQueryLanguageStatement.forStatementString("SHOW TABLES"));
+        executeStatement("SHOW TABLES");
     }
 
     public HiveConf getHiveConf() {

--- a/src/main/java/com/klarna/hiverunner/HiveServerContainer.java
+++ b/src/main/java/com/klarna/hiverunner/HiveServerContainer.java
@@ -17,7 +17,7 @@
 package com.klarna.hiverunner;
 
 import com.google.common.base.Preconditions;
-import com.klarna.hiverunner.sql.StatementsSplitter;
+
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.tez.TezJobMonitor;
 import org.apache.hadoop.hive.ql.parse.VariableSubstitution;
@@ -132,16 +132,6 @@ public class HiveServerContainer {
     }
 
     /**
-     * Executes a hive script.
-     * @param hiveql hive script statements.
-     */
-    public void executeScript(String hiveql) {
-        for (String statement : StatementsSplitter.splitStatements(hiveql)) {
-            executeStatement(statement);
-        }
-    }
-
-    /**
      * Release all resources.
      *
      * This call will never throw an exception as it makes no sense doing that in the tear down phase.
@@ -158,7 +148,7 @@ public class HiveServerContainer {
 
         try {
             // Reset to default schema
-            executeScript("USE default;");
+            executeStatement("USE default");
         } catch (Throwable e) {
             LOGGER.warn("Failed to reset to default schema: " + e.getMessage() +
                     ". Turn on log level debug for stacktrace");

--- a/src/main/java/com/klarna/hiverunner/builder/HiveShellBase.java
+++ b/src/main/java/com/klarna/hiverunner/builder/HiveShellBase.java
@@ -19,10 +19,10 @@ package com.klarna.hiverunner.builder;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.klarna.hiverunner.CommandShellEmulation;
-import com.klarna.hiverunner.HiveQueryLanguageStatement;
 import com.klarna.hiverunner.HiveServerContainer;
 import com.klarna.hiverunner.HiveShell;
 import com.klarna.hiverunner.data.InsertIntoTable;
+import com.klarna.hiverunner.hql.HiveQueryLanguageStatement;
 import com.klarna.hiverunner.sql.StatementsSplitter;
 
 import org.apache.hadoop.hive.conf.HiveConf;

--- a/src/main/java/com/klarna/hiverunner/builder/HiveShellBase.java
+++ b/src/main/java/com/klarna/hiverunner/builder/HiveShellBase.java
@@ -110,12 +110,7 @@ class HiveShellBase implements HiveShell {
     }
 
     private List<Object[]> importScript(String hql) {
-      String[] tokens = hql.trim().split("\\s+");
-      String fileName = null;
-      if (tokens.length == 2) {
-        fileName = tokens[1];
-      }
-      execute(new File(fileName));
+      execute(commandShellEmulation.getImportFileFromStatement(hql));
       return Collections.emptyList();
     }
 

--- a/src/main/java/com/klarna/hiverunner/builder/HiveShellBase.java
+++ b/src/main/java/com/klarna/hiverunner/builder/HiveShellBase.java
@@ -39,6 +39,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -101,7 +102,21 @@ class HiveShellBase implements HiveShell {
     }
     
     private List<Object[]> executeStatementWithCommandShellEmulation(String hql) {
-      return hiveServerContainer.executeStatement(commandShellEmulation.transformStatement(hql));
+      String transformedHql = commandShellEmulation.transformStatement(hql);
+      if (commandShellEmulation.isImportFileStatement(transformedHql)) {
+        return importScript(transformedHql);
+      }
+      return hiveServerContainer.executeStatement(transformedHql);
+    }
+
+    private List<Object[]> importScript(String hql) {
+      String[] tokens = hql.trim().split("\\s+");
+      String fileName = null;
+      if (tokens.length == 2) {
+        fileName = tokens[1];
+      }
+      execute(new File(fileName));
+      return Collections.emptyList();
     }
 
     @Override

--- a/src/main/java/com/klarna/hiverunner/builder/HiveShellBase.java
+++ b/src/main/java/com/klarna/hiverunner/builder/HiveShellBase.java
@@ -22,6 +22,7 @@ import com.klarna.hiverunner.CommandShellEmulation;
 import com.klarna.hiverunner.HiveServerContainer;
 import com.klarna.hiverunner.HiveShell;
 import com.klarna.hiverunner.data.InsertIntoTable;
+import com.klarna.hiverunner.sql.StatementsSplitter;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.junit.rules.TemporaryFolder;
@@ -319,7 +320,9 @@ class HiveShellBase implements HiveShell {
     }
 
     private void executeScriptWithCommandShellEmulation(String script) {
-          hiveServerContainer.executeScript(commandShellEmulation.transformScript(script));
+        for (String statement : StatementsSplitter.splitStatements(commandShellEmulation.transformScript(script))) {
+            executeStatement(statement);
+        }
     }
     
     protected final void assertResourcePreconditions(HiveResource resource, String expandedPath) {

--- a/src/main/java/com/klarna/hiverunner/builder/HiveShellBase.java
+++ b/src/main/java/com/klarna/hiverunner/builder/HiveShellBase.java
@@ -19,6 +19,7 @@ package com.klarna.hiverunner.builder;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.klarna.hiverunner.CommandShellEmulation;
+import com.klarna.hiverunner.HiveQueryLanguageStatement;
 import com.klarna.hiverunner.HiveServerContainer;
 import com.klarna.hiverunner.HiveShell;
 import com.klarna.hiverunner.data.InsertIntoTable;
@@ -106,7 +107,7 @@ class HiveShellBase implements HiveShell {
       if (commandShellEmulation.isImportFileStatement(transformedHql)) {
         return importScript(transformedHql);
       }
-      return hiveServerContainer.executeStatement(transformedHql);
+      return hiveServerContainer.executeStatement(HiveQueryLanguageStatement.forStatementString(transformedHql));
     }
 
     private List<Object[]> importScript(String hql) {

--- a/src/main/java/com/klarna/hiverunner/builder/HiveShellBase.java
+++ b/src/main/java/com/klarna/hiverunner/builder/HiveShellBase.java
@@ -331,8 +331,8 @@ class HiveShellBase implements HiveShell {
     }
 
     private void executeScriptWithCommandShellEmulation(String script) {
-        for (String statement : StatementsSplitter.splitStatements(commandShellEmulation.transformScript(script))) {
-            executeStatement(statement);
+        for (HiveQueryLanguageStatement statement : StatementsSplitter.splitStatements(commandShellEmulation.transformScript(script))) {
+            executeStatement(statement.getStatementString());
         }
     }
     

--- a/src/main/java/com/klarna/hiverunner/hql/HiveQueryLanguageStatement.java
+++ b/src/main/java/com/klarna/hiverunner/hql/HiveQueryLanguageStatement.java
@@ -1,4 +1,4 @@
-package com.klarna.hiverunner;
+package com.klarna.hiverunner.hql;
 
 public class HiveQueryLanguageStatement {
 

--- a/src/main/java/com/klarna/hiverunner/hql/HiveQueryLanguageStatement.java
+++ b/src/main/java/com/klarna/hiverunner/hql/HiveQueryLanguageStatement.java
@@ -2,13 +2,9 @@ package com.klarna.hiverunner.hql;
 
 public class HiveQueryLanguageStatement {
 
-    public static HiveQueryLanguageStatement forStatementString(String statementString) {
-        return new HiveQueryLanguageStatement(statementString.trim());
-    }
-
     private final String statementString;
 
-    private HiveQueryLanguageStatement(String statementString) {
+    HiveQueryLanguageStatement(String statementString) {
         this.statementString = statementString;
     }
 

--- a/src/main/java/com/klarna/hiverunner/hql/HiveQueryLanguageStatementFactory.java
+++ b/src/main/java/com/klarna/hiverunner/hql/HiveQueryLanguageStatementFactory.java
@@ -1,0 +1,57 @@
+package com.klarna.hiverunner.hql;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.klarna.hiverunner.CommandShellEmulation;
+import com.klarna.hiverunner.sql.StatementsSplitter;
+
+public class HiveQueryLanguageStatementFactory {
+
+	private final Charset charset;
+	private final CommandShellEmulation commandShellEmulation;
+
+	public HiveQueryLanguageStatementFactory(Charset charset, CommandShellEmulation commandShellEmulation) {
+		this.charset = charset;
+		this.commandShellEmulation = commandShellEmulation;
+	}
+
+	public List<HiveQueryLanguageStatement> newInstanceForScript(String script) {
+		List<HiveQueryLanguageStatement> hqlStatements = new ArrayList<>();
+		List<String> statements = StatementsSplitter.splitStatements(commandShellEmulation.transformScript(script));
+		for (String statement : statements) {
+			hqlStatements.addAll(newInstanceForStatement(statement));
+		}
+		return hqlStatements;
+	}
+
+	public List<HiveQueryLanguageStatement> newInstanceForStatement(String statement) {
+		List<HiveQueryLanguageStatement> hqlStatements = new ArrayList<>();
+		String trimmedStatement = statement.trim();
+		if (commandShellEmulation.isImportFileStatement(trimmedStatement)) {
+			File importFile = commandShellEmulation.getImportFileFromStatement(trimmedStatement);
+			Path path = Paths.get(importFile.toURI());
+			hqlStatements.addAll(newInstanceForPath(path));
+		} else {
+			String transformedHql = commandShellEmulation.transformStatement(trimmedStatement);
+			hqlStatements.add(new HiveQueryLanguageStatement(transformedHql));
+		}
+		return hqlStatements;
+	}
+
+	public List<HiveQueryLanguageStatement> newInstanceForPath(Path path) {
+		try {
+			String script = new String(Files.readAllBytes(path), charset);
+			return newInstanceForScript(script);
+		} catch (IOException e) {
+			throw new IllegalArgumentException("Unable to read script file '" + path + "': " + e.getMessage(), e);
+		}
+	}
+
+}

--- a/src/main/java/com/klarna/hiverunner/sql/StatementsSplitter.java
+++ b/src/main/java/com/klarna/hiverunner/sql/StatementsSplitter.java
@@ -1,5 +1,7 @@
 package com.klarna.hiverunner.sql;
 
+import com.klarna.hiverunner.HiveQueryLanguageStatement;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
@@ -40,10 +42,10 @@ public class StatementsSplitter {
      * Also, detects Beeline's SQLLine commands (commands start with '!' and do not end with ';').
      * ';' within quotes (" or ') or comments ( -- ) are ignored.
      */
-    public static List<String> splitStatements(String expression) {
+    public static List<HiveQueryLanguageStatement> splitStatements(String expression) {
         StringTokenizer tokenizer = new StringTokenizer(expression, SQL_SPECIAL_CHARS + BEELINE_SPECIAL_CHARS, true);
 
-        List<String> statements = new ArrayList<>();
+        List<HiveQueryLanguageStatement> statements = new ArrayList<>();
         String statement = "";
         while (tokenizer.hasMoreElements()) {
             String token = (String) tokenizer.nextElement();
@@ -53,7 +55,7 @@ public class StatementsSplitter {
                 case ";":
                     // Only add statement that is not empty
                     if (isValidStatement(statement)) {
-                        statements.add(statement.trim());
+                        statements.add(HiveQueryLanguageStatement.forStatementString(statement));
                     }
                     statement = "";
                     break;
@@ -79,7 +81,7 @@ public class StatementsSplitter {
                         statement += readUntilEndOfLine(tokenizer);
                         // Only add statement that is not empty
                         if (isValidStatement(statement)) {
-                            statements.add(statement.trim());
+                            statements.add(HiveQueryLanguageStatement.forStatementString(statement));
                         }
                         statement = "";
                         break;
@@ -93,7 +95,7 @@ public class StatementsSplitter {
 
         // Only add statement that is not empty
         if (isValidStatement(statement)) {
-            statements.add(statement);
+            statements.add(HiveQueryLanguageStatement.forStatementString(statement));
         }
         return statements;
     }

--- a/src/main/java/com/klarna/hiverunner/sql/StatementsSplitter.java
+++ b/src/main/java/com/klarna/hiverunner/sql/StatementsSplitter.java
@@ -1,6 +1,6 @@
 package com.klarna.hiverunner.sql;
 
-import com.klarna.hiverunner.HiveQueryLanguageStatement;
+import com.klarna.hiverunner.hql.HiveQueryLanguageStatement;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/klarna/hiverunner/sql/StatementsSplitter.java
+++ b/src/main/java/com/klarna/hiverunner/sql/StatementsSplitter.java
@@ -1,7 +1,5 @@
 package com.klarna.hiverunner.sql;
 
-import com.klarna.hiverunner.hql.HiveQueryLanguageStatement;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
@@ -42,10 +40,10 @@ public class StatementsSplitter {
      * Also, detects Beeline's SQLLine commands (commands start with '!' and do not end with ';').
      * ';' within quotes (" or ') or comments ( -- ) are ignored.
      */
-    public static List<HiveQueryLanguageStatement> splitStatements(String expression) {
+    public static List<String> splitStatements(String expression) {
         StringTokenizer tokenizer = new StringTokenizer(expression, SQL_SPECIAL_CHARS + BEELINE_SPECIAL_CHARS, true);
 
-        List<HiveQueryLanguageStatement> statements = new ArrayList<>();
+        List<String> statements = new ArrayList<>();
         String statement = "";
         while (tokenizer.hasMoreElements()) {
             String token = (String) tokenizer.nextElement();
@@ -55,7 +53,7 @@ public class StatementsSplitter {
                 case ";":
                     // Only add statement that is not empty
                     if (isValidStatement(statement)) {
-                        statements.add(HiveQueryLanguageStatement.forStatementString(statement));
+                        statements.add(statement.trim());
                     }
                     statement = "";
                     break;
@@ -81,7 +79,7 @@ public class StatementsSplitter {
                         statement += readUntilEndOfLine(tokenizer);
                         // Only add statement that is not empty
                         if (isValidStatement(statement)) {
-                            statements.add(HiveQueryLanguageStatement.forStatementString(statement));
+                            statements.add(statement.trim());
                         }
                         statement = "";
                         break;
@@ -95,7 +93,7 @@ public class StatementsSplitter {
 
         // Only add statement that is not empty
         if (isValidStatement(statement)) {
-            statements.add(HiveQueryLanguageStatement.forStatementString(statement));
+            statements.add(statement.trim());
         }
         return statements;
     }

--- a/src/test/java/com/klarna/hiverunner/CommandShellEmulationTest.java
+++ b/src/test/java/com/klarna/hiverunner/CommandShellEmulationTest.java
@@ -73,6 +73,8 @@ public class CommandShellEmulationTest {
   @Test
   public void hiveCliEmulationSupportsImportingScriptFiles() {
     assertThat(CommandShellEmulation.HIVE_CLI.isImportFileStatement("source script.hql"), is(true));
+    assertThat(CommandShellEmulation.HIVE_CLI.isImportFileStatement("   source script.hql  "), is(true));
+    assertThat(CommandShellEmulation.HIVE_CLI.isImportFileStatement("SOURCE script.hql"), is(true));
 
     assertThat(CommandShellEmulation.HIVE_CLI.isImportFileStatement("!run script.hql"), is(false));
     assertThat(CommandShellEmulation.HIVE_CLI.isImportFileStatement("select * from table"), is(false));
@@ -80,10 +82,12 @@ public class CommandShellEmulationTest {
 
   @Test
   public void beeLineEmulationSupportsImportingScriptFiles() {
-     assertThat(CommandShellEmulation.BEELINE.isImportFileStatement("!run script.hql"), is(true));
+    assertThat(CommandShellEmulation.BEELINE.isImportFileStatement("!run script.hql"), is(true));
+    assertThat(CommandShellEmulation.BEELINE.isImportFileStatement("   !run script.hql   "), is(true));
 
-     assertThat(CommandShellEmulation.BEELINE.isImportFileStatement("source script.hql"), is(false));
-     assertThat(CommandShellEmulation.BEELINE.isImportFileStatement("select * from table"), is(false));
+    assertThat(CommandShellEmulation.BEELINE.isImportFileStatement("!RUN script.hql"), is(false));
+    assertThat(CommandShellEmulation.BEELINE.isImportFileStatement("source script.hql"), is(false));
+    assertThat(CommandShellEmulation.BEELINE.isImportFileStatement("select * from table"), is(false));
   }
 
 }

--- a/src/test/java/com/klarna/hiverunner/CommandShellEmulationTest.java
+++ b/src/test/java/com/klarna/hiverunner/CommandShellEmulationTest.java
@@ -16,9 +16,12 @@
 package com.klarna.hiverunner;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.isEmptyString;
 import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
+
+import java.io.File;
 
 public class CommandShellEmulationTest {
 
@@ -81,6 +84,20 @@ public class CommandShellEmulationTest {
   }
 
   @Test
+  public void hiveCliEmulationReturnsScriptFileToImport() {
+    File expected = new File("script.hql");
+
+    assertThat(CommandShellEmulation.HIVE_CLI.getImportFileFromStatement("source script.hql"), is(expected));
+    assertThat(CommandShellEmulation.HIVE_CLI.getImportFileFromStatement("   source   script.hql   "), is(expected));
+  }
+
+  @Test
+  public void hiveCliEmulationReturnsFileWithoutNameWhenImportStatementIsMalformed() {
+    File actual = CommandShellEmulation.HIVE_CLI.getImportFileFromStatement("source");
+    assertThat(actual.getName(), isEmptyString());
+  }
+
+  @Test
   public void beeLineEmulationSupportsImportingScriptFiles() {
     assertThat(CommandShellEmulation.BEELINE.isImportFileStatement("!run script.hql"), is(true));
     assertThat(CommandShellEmulation.BEELINE.isImportFileStatement("   !run script.hql   "), is(true));
@@ -88,6 +105,19 @@ public class CommandShellEmulationTest {
     assertThat(CommandShellEmulation.BEELINE.isImportFileStatement("!RUN script.hql"), is(false));
     assertThat(CommandShellEmulation.BEELINE.isImportFileStatement("source script.hql"), is(false));
     assertThat(CommandShellEmulation.BEELINE.isImportFileStatement("select * from table"), is(false));
+  }
+
+  @Test
+  public void beeLineEmulationReturnsScriptFileToImport() {
+    File expected = new File("script.hql");
+
+    assertThat(CommandShellEmulation.BEELINE.getImportFileFromStatement("!run script.hql"), is(expected));
+    assertThat(CommandShellEmulation.BEELINE.getImportFileFromStatement("   !run script.hql   "), is(expected));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void illegalArgumentExceptionIsThrownWhenBeeLineEmulationCannotGetImportFileFromStatement() {
+    CommandShellEmulation.BEELINE.getImportFileFromStatement("!run script.hql another_script.hql");
   }
 
 }

--- a/src/test/java/com/klarna/hiverunner/CommandShellEmulationTest.java
+++ b/src/test/java/com/klarna/hiverunner/CommandShellEmulationTest.java
@@ -69,5 +69,21 @@ public class CommandShellEmulationTest {
     String hql = "-- hello";
     assertThat(CommandShellEmulation.HIVE_CLI.transformScript(hql), is(""));
   }
-  
+
+  @Test
+  public void hiveCliEmulationSupportsImportingScriptFiles() {
+    assertThat(CommandShellEmulation.HIVE_CLI.isImportFileStatement("source script.hql"), is(true));
+
+    assertThat(CommandShellEmulation.HIVE_CLI.isImportFileStatement("!run script.hql"), is(false));
+    assertThat(CommandShellEmulation.HIVE_CLI.isImportFileStatement("select * from table"), is(false));
+  }
+
+  @Test
+  public void beeLineEmulationSupportsImportingScriptFiles() {
+     assertThat(CommandShellEmulation.BEELINE.isImportFileStatement("!run script.hql"), is(true));
+
+     assertThat(CommandShellEmulation.BEELINE.isImportFileStatement("source script.hql"), is(false));
+     assertThat(CommandShellEmulation.BEELINE.isImportFileStatement("select * from table"), is(false));
+  }
+
 }

--- a/src/test/java/com/klarna/hiverunner/HiveServerContainerTest.java
+++ b/src/test/java/com/klarna/hiverunner/HiveServerContainerTest.java
@@ -16,6 +16,7 @@
 package com.klarna.hiverunner;
 
 import com.klarna.hiverunner.config.HiveRunnerConfig;
+import com.klarna.hiverunner.hql.HiveQueryLanguageStatement;
 
 import org.apache.hive.service.cli.HiveSQLException;
 import org.junit.After;

--- a/src/test/java/com/klarna/hiverunner/HiveServerContainerTest.java
+++ b/src/test/java/com/klarna/hiverunner/HiveServerContainerTest.java
@@ -16,6 +16,7 @@
 package com.klarna.hiverunner;
 
 import com.klarna.hiverunner.config.HiveRunnerConfig;
+
 import org.apache.hive.service.cli.HiveSQLException;
 import org.junit.After;
 import org.junit.Assert;
@@ -55,14 +56,16 @@ public class HiveServerContainerTest {
 
     @Test
     public void testExecuteStatementMR() {
-        List<Object[]> actual = container.executeStatement("show databases");
+        HiveQueryLanguageStatement hqlStatement = HiveQueryLanguageStatement.forStatementString("show databases");
+        List<Object[]> actual = container.executeStatement(hqlStatement);
         Assert.assertEquals(1, actual.size());
         Assert.assertArrayEquals(new Object[]{"default"}, actual.get(0));
     }
 
     @Test
     public void testExecuteStatementTez() {
-        List<Object[]> actual = container.executeStatement("show databases");
+        HiveQueryLanguageStatement hqlStatement = HiveQueryLanguageStatement.forStatementString("show databases");
+        List<Object[]> actual = container.executeStatement(hqlStatement);
         Assert.assertEquals(1, actual.size());
         Assert.assertArrayEquals(new Object[]{"default"}, actual.get(0));
     }
@@ -76,8 +79,9 @@ public class HiveServerContainerTest {
 
     @Test(expected = HiveSQLException.class)
     public void testInvalidQuery() throws Throwable {
+        HiveQueryLanguageStatement hqlStatement = HiveQueryLanguageStatement.forStatementString("use foo");
         try {
-            container.executeStatement("use foo");
+            container.executeStatement(hqlStatement);
         } catch (IllegalArgumentException e) {
             throw e.getCause();
         }

--- a/src/test/java/com/klarna/hiverunner/HiveServerContainerTest.java
+++ b/src/test/java/com/klarna/hiverunner/HiveServerContainerTest.java
@@ -15,8 +15,8 @@
  */
 package com.klarna.hiverunner;
 
-import com.klarna.hiverunner.config.HiveRunnerConfig;
-import com.klarna.hiverunner.hql.HiveQueryLanguageStatement;
+import java.util.HashMap;
+import java.util.List;
 
 import org.apache.hive.service.cli.HiveSQLException;
 import org.junit.After;
@@ -26,11 +26,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.util.HashMap;
-import java.util.List;
+import com.klarna.hiverunner.config.HiveRunnerConfig;
 
 public class HiveServerContainerTest {
-
 
     @Rule
     public TemporaryFolder basedir = new TemporaryFolder();
@@ -57,16 +55,16 @@ public class HiveServerContainerTest {
 
     @Test
     public void testExecuteStatementMR() {
-        HiveQueryLanguageStatement hqlStatement = HiveQueryLanguageStatement.forStatementString("show databases");
-        List<Object[]> actual = container.executeStatement(hqlStatement);
+        String hql = "show databases";
+        List<Object[]> actual = container.executeStatement(hql);
         Assert.assertEquals(1, actual.size());
         Assert.assertArrayEquals(new Object[]{"default"}, actual.get(0));
     }
 
     @Test
     public void testExecuteStatementTez() {
-        HiveQueryLanguageStatement hqlStatement = HiveQueryLanguageStatement.forStatementString("show databases");
-        List<Object[]> actual = container.executeStatement(hqlStatement);
+        String hql = "show databases";
+        List<Object[]> actual = container.executeStatement(hql);
         Assert.assertEquals(1, actual.size());
         Assert.assertArrayEquals(new Object[]{"default"}, actual.get(0));
     }
@@ -80,9 +78,8 @@ public class HiveServerContainerTest {
 
     @Test(expected = HiveSQLException.class)
     public void testInvalidQuery() throws Throwable {
-        HiveQueryLanguageStatement hqlStatement = HiveQueryLanguageStatement.forStatementString("use foo");
         try {
-            container.executeStatement(hqlStatement);
+            container.executeStatement("use foo");
         } catch (IllegalArgumentException e) {
             throw e.getCause();
         }

--- a/src/test/java/com/klarna/hiverunner/builder/HiveShellBaseTest.java
+++ b/src/test/java/com/klarna/hiverunner/builder/HiveShellBaseTest.java
@@ -1,10 +1,10 @@
 package com.klarna.hiverunner.builder;
 
-import com.klarna.hiverunner.CommandShellEmulation;
 import static com.google.common.base.Charsets.UTF_8;
 import static org.mockito.Mockito.verify;
 
 import com.google.common.io.Files;
+import com.klarna.hiverunner.CommandShellEmulation;
 import com.klarna.hiverunner.HiveServerContainer;
 import com.klarna.hiverunner.HiveServerContext;
 import com.klarna.hiverunner.HiveShell;
@@ -77,7 +77,7 @@ public class HiveShellBaseTest {
 
     @Test
     public void executeScriptFile() throws IOException {
-      String hql = "use default;";
+      String hql = "use default";
 
       File file = new File(tempFolder.getRoot(), "script.hql");
       Files.write(hql, file, UTF_8);
@@ -86,12 +86,12 @@ public class HiveShellBaseTest {
       shell.start();
       shell.execute(file);
 
-      verify(container).executeScript(hql);
+      verify(container).executeStatement(hql);
     }
 
     @Test
     public void executeScriptCharsetFile() throws IOException {
-      String hql = "use default;";
+      String hql = "use default";
 
       File file = new File(tempFolder.getRoot(), "script.hql");
       Files.write(hql, file, UTF_8);
@@ -100,12 +100,12 @@ public class HiveShellBaseTest {
       shell.start();
       shell.execute(UTF_8, file);
 
-      verify(container).executeScript(hql);
+      verify(container).executeStatement(hql);
     }
     
     @Test
     public void executeScriptPath() throws IOException {
-      String hql = "use default;";
+      String hql = "use default";
 
       File file = new File(tempFolder.getRoot(), "script.hql");
       Files.write(hql, file, UTF_8);
@@ -114,12 +114,12 @@ public class HiveShellBaseTest {
       shell.start();
       shell.execute(Paths.get(file.toURI()));
 
-      verify(container).executeScript(hql);
+      verify(container).executeStatement(hql);
     }
 
     @Test
     public void executeScriptCharsetPath() throws IOException {
-      String hql = "use default;";
+      String hql = "use default";
 
       File file = new File(tempFolder.getRoot(), "script.hql");
       Files.write(hql, file, UTF_8);
@@ -128,7 +128,7 @@ public class HiveShellBaseTest {
       shell.start();
       shell.execute(UTF_8, Paths.get(file.toURI()));
 
-      verify(container).executeScript(hql);
+      verify(container).executeStatement(hql);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/com/klarna/hiverunner/builder/HiveShellBaseTest.java
+++ b/src/test/java/com/klarna/hiverunner/builder/HiveShellBaseTest.java
@@ -8,10 +8,10 @@ import static org.mockito.Mockito.verify;
 
 import com.google.common.io.Files;
 import com.klarna.hiverunner.CommandShellEmulation;
-import com.klarna.hiverunner.HiveQueryLanguageStatement;
 import com.klarna.hiverunner.HiveServerContainer;
 import com.klarna.hiverunner.HiveServerContext;
 import com.klarna.hiverunner.HiveShell;
+import com.klarna.hiverunner.hql.HiveQueryLanguageStatement;
 
 import org.apache.commons.collections.MapUtils;
 import org.apache.hadoop.hive.conf.HiveConf;

--- a/src/test/java/com/klarna/hiverunner/builder/HiveShellBaseTest.java
+++ b/src/test/java/com/klarna/hiverunner/builder/HiveShellBaseTest.java
@@ -1,6 +1,9 @@
 package com.klarna.hiverunner.builder;
 
 import static com.google.common.base.Charsets.UTF_8;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verify;
 
 import com.google.common.io.Files;
@@ -146,6 +149,42 @@ public class HiveShellBaseTest {
       
       HiveShell shell = createHiveShell();
       shell.execute(UTF_8, Paths.get(file.toURI()));
+    }
+
+    @Test
+    public void scriptFilesAreImportedInQueries() throws IOException {
+      String hql = "use default";
+
+      File importedFile = new File(tempFolder.getRoot(), "imported_script.hql");
+      Files.write(hql, importedFile, UTF_8);
+
+      HiveShell shell = createHiveShell();
+      shell.start();
+
+      String importHql = "source " + importedFile.getAbsolutePath();
+      List<String> results = shell.executeQuery(importHql);
+
+      assertThat(results, is(empty()));
+      verify(container).executeStatement(hql);
+    }
+
+    @Test
+    public void scriptFilesAreImportedInOtherScripts() throws IOException {
+      String hql = "use default";
+
+      File importedFile = new File(tempFolder.getRoot(), "imported_script.hql");
+      Files.write(hql, importedFile, UTF_8);
+
+      HiveShell shell = createHiveShell();
+      shell.start();
+
+      String importHql = "source " + importedFile.getAbsolutePath();
+      File file = new File(tempFolder.getRoot(), "script.hql");
+      Files.write(importHql, file, UTF_8);
+
+      shell.execute(file);
+
+      verify(container).executeStatement(hql);
     }
 
     private HiveShell createHiveShell(String... keyValues) {

--- a/src/test/java/com/klarna/hiverunner/builder/HiveShellBaseTest.java
+++ b/src/test/java/com/klarna/hiverunner/builder/HiveShellBaseTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 
 import com.google.common.io.Files;
 import com.klarna.hiverunner.CommandShellEmulation;
+import com.klarna.hiverunner.HiveQueryLanguageStatement;
 import com.klarna.hiverunner.HiveServerContainer;
 import com.klarna.hiverunner.HiveServerContext;
 import com.klarna.hiverunner.HiveShell;
@@ -18,7 +19,11 @@ import org.apache.hive.service.cli.CLIService;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,12 +33,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@RunWith(MockitoJUnitRunner.class)
 public class HiveShellBaseTest {
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
 
     private HiveServerContainer container;
+    @Captor
+    private ArgumentCaptor<HiveQueryLanguageStatement> hqlStatementCaptor;
 
     @Test(expected = IllegalStateException.class)
     public void variableSubstitutionShouldBlowUpIfShellIsNotStarted() {
@@ -89,7 +97,8 @@ public class HiveShellBaseTest {
       shell.start();
       shell.execute(file);
 
-      verify(container).executeStatement(hql);
+      verify(container).executeStatement(hqlStatementCaptor.capture());
+      assertThat(hqlStatementCaptor.getValue().getStatementString(), is(hql));
     }
 
     @Test
@@ -103,7 +112,8 @@ public class HiveShellBaseTest {
       shell.start();
       shell.execute(UTF_8, file);
 
-      verify(container).executeStatement(hql);
+      verify(container).executeStatement(hqlStatementCaptor.capture());
+      assertThat(hqlStatementCaptor.getValue().getStatementString(), is(hql));
     }
     
     @Test
@@ -117,7 +127,8 @@ public class HiveShellBaseTest {
       shell.start();
       shell.execute(Paths.get(file.toURI()));
 
-      verify(container).executeStatement(hql);
+      verify(container).executeStatement(hqlStatementCaptor.capture());
+      assertThat(hqlStatementCaptor.getValue().getStatementString(), is(hql));
     }
 
     @Test
@@ -131,7 +142,8 @@ public class HiveShellBaseTest {
       shell.start();
       shell.execute(UTF_8, Paths.get(file.toURI()));
 
-      verify(container).executeStatement(hql);
+      verify(container).executeStatement(hqlStatementCaptor.capture());
+      assertThat(hqlStatementCaptor.getValue().getStatementString(), is(hql));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -165,7 +177,8 @@ public class HiveShellBaseTest {
       List<String> results = shell.executeQuery(importHql);
 
       assertThat(results, is(empty()));
-      verify(container).executeStatement(hql);
+      verify(container).executeStatement(hqlStatementCaptor.capture());
+      assertThat(hqlStatementCaptor.getValue().getStatementString(), is(hql));
     }
 
     @Test
@@ -184,7 +197,8 @@ public class HiveShellBaseTest {
 
       shell.execute(file);
 
-      verify(container).executeStatement(hql);
+      verify(container).executeStatement(hqlStatementCaptor.capture());
+      assertThat(hqlStatementCaptor.getValue().getStatementString(), is(hql));
     }
 
     private HiveShell createHiveShell(String... keyValues) {

--- a/src/test/java/com/klarna/hiverunner/builder/HiveShellBaseTest.java
+++ b/src/test/java/com/klarna/hiverunner/builder/HiveShellBaseTest.java
@@ -11,7 +11,6 @@ import com.klarna.hiverunner.CommandShellEmulation;
 import com.klarna.hiverunner.HiveServerContainer;
 import com.klarna.hiverunner.HiveServerContext;
 import com.klarna.hiverunner.HiveShell;
-import com.klarna.hiverunner.hql.HiveQueryLanguageStatement;
 
 import org.apache.commons.collections.MapUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -19,11 +18,7 @@ import org.apache.hive.service.cli.CLIService;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,15 +28,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@RunWith(MockitoJUnitRunner.class)
 public class HiveShellBaseTest {
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
 
     private HiveServerContainer container;
-    @Captor
-    private ArgumentCaptor<HiveQueryLanguageStatement> hqlStatementCaptor;
 
     @Test(expected = IllegalStateException.class)
     public void variableSubstitutionShouldBlowUpIfShellIsNotStarted() {
@@ -97,8 +89,7 @@ public class HiveShellBaseTest {
       shell.start();
       shell.execute(file);
 
-      verify(container).executeStatement(hqlStatementCaptor.capture());
-      assertThat(hqlStatementCaptor.getValue().getStatementString(), is(hql));
+      verify(container).executeStatement(hql);
     }
 
     @Test
@@ -112,8 +103,7 @@ public class HiveShellBaseTest {
       shell.start();
       shell.execute(UTF_8, file);
 
-      verify(container).executeStatement(hqlStatementCaptor.capture());
-      assertThat(hqlStatementCaptor.getValue().getStatementString(), is(hql));
+      verify(container).executeStatement(hql);
     }
     
     @Test
@@ -127,8 +117,7 @@ public class HiveShellBaseTest {
       shell.start();
       shell.execute(Paths.get(file.toURI()));
 
-      verify(container).executeStatement(hqlStatementCaptor.capture());
-      assertThat(hqlStatementCaptor.getValue().getStatementString(), is(hql));
+      verify(container).executeStatement(hql);
     }
 
     @Test
@@ -142,8 +131,7 @@ public class HiveShellBaseTest {
       shell.start();
       shell.execute(UTF_8, Paths.get(file.toURI()));
 
-      verify(container).executeStatement(hqlStatementCaptor.capture());
-      assertThat(hqlStatementCaptor.getValue().getStatementString(), is(hql));
+      verify(container).executeStatement(hql);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -177,8 +165,7 @@ public class HiveShellBaseTest {
       List<String> results = shell.executeQuery(importHql);
 
       assertThat(results, is(empty()));
-      verify(container).executeStatement(hqlStatementCaptor.capture());
-      assertThat(hqlStatementCaptor.getValue().getStatementString(), is(hql));
+      verify(container).executeStatement(hql);
     }
 
     @Test
@@ -197,8 +184,7 @@ public class HiveShellBaseTest {
 
       shell.execute(file);
 
-      verify(container).executeStatement(hqlStatementCaptor.capture());
-      assertThat(hqlStatementCaptor.getValue().getStatementString(), is(hql));
+      verify(container).executeStatement(hql);
     }
 
     private HiveShell createHiveShell(String... keyValues) {

--- a/src/test/java/com/klarna/hiverunner/sql/StatementsSplitterTest.java
+++ b/src/test/java/com/klarna/hiverunner/sql/StatementsSplitterTest.java
@@ -1,6 +1,7 @@
 package com.klarna.hiverunner.sql;
 
 import com.google.common.base.Joiner;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -158,6 +159,18 @@ public class StatementsSplitterTest {
         Assert.assertEquals("\n", StatementsSplitter.readUntilEndOfLine(tokenizer));
         Assert.assertEquals("baz", StatementsSplitter.readUntilEndOfLine(tokenizer));
         Assert.assertEquals("", StatementsSplitter.readUntilEndOfLine(tokenizer));
+    }
+
+    @Test
+    public void beelineSqlLineCommandsAreSupported() {
+        String statementA = "!run script.hql";
+        String statementB = "select * from table where foo != bar";
+        String statementC = "!run another_script.hql";
+
+        List<String> expected = Arrays.asList(statementA, statementB, statementC);
+        String expression = statementA + '\n' + statementB + ";   " + statementC;
+
+        Assert.assertEquals(expected, StatementsSplitter.splitStatements(expression));
     }
 
 }


### PR DESCRIPTION
I added support for `source` (HiveCli) and `!run` (Beeline) commands. These commands allow to import and execute scripts in statements or scripts. This allows to compose and reuse HQL scripts.

Since these commands are not part of the core language I limited changes to the parts that emulate CLI-specific behaviour. Let me know what you think.

Some remarks:

(1) To keep `HiveServerContainer` agnostic to the used CLI I moved splitting scripts into statements out of the class. Afterwards, I removed the now unused `HiveServerContainer#executeScript` (it does not support `source/!run`). This breaks backwards compatibility. If deprecation is a better option commit `2d495443b8cc31ac99ca7c7fec77e4b193d78f0b` can be reverted.

(2) I noticed that [Beeline's SQLLine](https://cwiki.apache.org/confluence/display/Hive/HiveServer2+Clients#HiveServer2Clients-BeelineCommands) commands are not supported/emulated (for example, `!run` or `!quit`). If these should be supported in the future further refactorings could be done.

Here's an idea instead of string statements:
```
class Statement {

  private final StatementType type;
  private final String value;
  
  // ... constructor + getters for members omitted
  
  String[] getTokens() {
    return value.trim().split("\\s+");
  } 
}
```
```
enum StatementType {
  /* */
  HQL,
  /* supported by both CLIs */
  IMPORT_FILE,
  /* */
  HIVE_CLI_SPECIFIC_COMMAND,
  /* */
  BEELINE_SPECIFIC_COMMAND,
  
  // ...
}
```

This would also simplify my changes a bit more.

Example usage:
```
for (Statement statement : StatementsSplitter.splitStatements(commandShellEmulation.transformScript(script))) {
  if (StatementType.HQL == statement.getType()) {
    execute(statement);
  } else if (StatementType.IMPORT_FILE == statement.getType()) {
  	// ...
  }
}
```