### PR TITLE
Hive1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,12 +227,11 @@ Future work and Limitations
 Change Log (From version 2.2.0 and onwards)
 ==============
 
-### __2.7.0__
+### __3.0.0__
 
-* Updated to Hive 1.2.1.                                            
-* Removed the custom HiveConf hive.vs. Use hadoop.tmp.dir instead. 
-* As of Hive 1.2 there are a number of new reserved keywords, e.g. date, timestamp and update. If you happen to have one of these as an identifier, 
-you could either backtick quote the field name (e.g. \`date\`, \`timestamp\` or \`update\`) or set hive.support.sql11.reserved.keywords=false.  
+* Upgraded to Hive 1.2.1 (Note: new major release with backwards incompatibility issues). As of Hive 1.2 there are a number of new reserved keywords, see [DDL manual](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-Keywords,Non-reservedKeywordsandReservedKeywords) for more information. 
+If you happen to have one of these as an identifier, you could either backtick quote them (e.g. \`date\`, \`timestamp\` or \`update\`) or set hive.support.sql11.reserved.keywords=false.                                            
+* Removed the custom HiveConf hive.vs. Use hadoop.tmp.dir instead.   
 
 ### __2.6.0__
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,8 @@ Change Log (From version 2.2.0 and onwards)
 
 * Upgraded to Hive 1.2.1 (Note: new major release with backwards incompatibility issues). As of Hive 1.2 there are a number of new reserved keywords, see [DDL manual](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-Keywords,Non-reservedKeywordsandReservedKeywords) for more information. 
 If you happen to have one of these as an identifier, you could either backtick quote them (e.g. \`date\`, \`timestamp\` or \`update\`) or set hive.support.sql11.reserved.keywords=false.                                            
-* Removed the custom HiveConf hive.vs. Use hadoop.tmp.dir instead.   
+* Removed the custom HiveConf hive.vs. Use hadoop.tmp.dir instead.
+* Users of Hive version 0.14 or older are recommended to use HiveRunner version 2.6.0.
 
 ### __2.6.0__
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ Change Log (From version 2.2.0 and onwards)
 
 * Updated to Hive 1.2.1.                                            
 * Removed the custom HiveConf hive.vs. Use hadoop.tmp.dir instead. 
+* As of Hive 1.2 there are a number of new reserved keywords, e.g. date, timestamp and update. If you happen to have one of these as an identifier, 
+you could either backtick quote the field name (e.g. \`date\`, \`timestamp\` or \`update\`) or set hive.support.sql11.reserved.keywords=false.  
 
 ### __2.6.0__
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,12 @@ Future work and Limitations
 Change Log (From version 2.2.0 and onwards)
 ==============
 
-### __2.6.0-SNAPSHOT__
+### __2.7.0__
+
+* Updated to Hive 1.2.1.                                            
+* Removed the custom HiveConf hive.vs. Use hadoop.tmp.dir instead. 
+
+### __2.6.0__
 
 * Introduced command shell emulations to replicate different handling of full line comments in `hive` and `beeline` shells.
 Now strips full line comments for executed scripts to match the behaviour of the `hive -f` file option. 

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tez.version>0.7.0</tez.version>
         <hive.version>1.2.1</hive.version>
+        <hive.execution.engine>mr</hive.execution.engine>
     </properties>
 
     <dependencies>
@@ -195,7 +196,7 @@
                         <!--
                         Any hive conf property may be overridden here by suffixing it with 'hiveconf_'
                         -->
-                        <hiveconf_hive.execution.engine>mr</hiveconf_hive.execution.engine>
+                        <hiveconf_hive.execution.engine>${hive.execution.engine}</hiveconf_hive.execution.engine>
                         <hiveconf_hive.exec.counters.pull.interval>1000</hiveconf_hive.exec.counters.pull.interval>
                         <enableTimeout>false</enableTimeout>
                         <timeoutSeconds>30</timeoutSeconds>
@@ -288,6 +289,12 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>tez</id>
+            <properties>
+                <hive.execution.engine>tez</hive.execution.engine>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.klarna</groupId>
     <artifactId>hiverunner</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>HiveRunner</name>
     <description>HiveRunner is a unit test framework based on JUnit4 and enables TDD development of HiveQL without the need of any installed dependencies.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.klarna</groupId>
     <artifactId>hiverunner</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.7.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>HiveRunner</name>
     <description>HiveRunner is a unit test framework based on JUnit4 and enables TDD development of HiveQL without the need of any installed dependencies.</description>
@@ -40,7 +40,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tez.version>0.7.0</tez.version>
-        <hive.version>0.14.0</hive.version>
+        <hive.version>1.2.1</hive.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/com/klarna/hiverunner/StandaloneHiveServerContext.java
+++ b/src/main/java/com/klarna/hiverunner/StandaloneHiveServerContext.java
@@ -195,7 +195,6 @@ public class StandaloneHiveServerContext implements HiveServerContext {
 
         createAndSetFolderProperty("hadoop.tmp.dir", "hadooptmp", conf, basedir);
         createAndSetFolderProperty("test.log.dir", "logs", conf, basedir);
-        createAndSetFolderProperty("hive.vs", "vs", conf, basedir);
 
 
 

--- a/src/main/java/com/klarna/hiverunner/StandaloneHiveServerContext.java
+++ b/src/main/java/com/klarna/hiverunner/StandaloneHiveServerContext.java
@@ -75,8 +75,6 @@ public class StandaloneHiveServerContext implements HiveServerContext {
 
         configureFileSystem(basedir, hiveConf);
 
-        configureCheckForDefaultDb(hiveConf);
-
         configureAssertionStatus(hiveConf);
 
         overrideHiveConf(hiveConf);
@@ -158,10 +156,6 @@ public class StandaloneHiveServerContext implements HiveServerContext {
                 false);
     }
 
-    protected void configureCheckForDefaultDb(HiveConf conf) {
-        hiveConf.setBoolean("hive.metastore.checkForDefaultDb", true);
-    }
-
     protected void configureSupportConcurrency(HiveConf conf) {
         hiveConf.setBoolVar(HIVE_SUPPORT_CONCURRENCY, false);
     }
@@ -195,7 +189,6 @@ public class StandaloneHiveServerContext implements HiveServerContext {
         createAndSetFolderProperty(METASTOREWAREHOUSE, "warehouse", conf, basedir);
         createAndSetFolderProperty(SCRATCHDIR, "scratchdir", conf, basedir);
         createAndSetFolderProperty(LOCALSCRATCHDIR, "localscratchdir", conf, basedir);
-        createAndSetFolderProperty("hive.metastore.metadb.dir", "metastore", conf, basedir);
         createAndSetFolderProperty(HIVEHISTORYFILELOC, "tmp", conf, basedir);
 
         conf.setBoolVar(HIVE_WAREHOUSE_SUBDIR_INHERIT_PERMS, true);

--- a/src/test/java/com/klarna/hiverunner/BigResultSetTest.java
+++ b/src/test/java/com/klarna/hiverunner/BigResultSetTest.java
@@ -40,7 +40,7 @@ public class BigResultSetTest {
      */
     @Test
     public void bigResultSetTest() throws IOException {
-        hiveShell.setProperty("location", "${hiveconf:hadoop.tmp.dir}/foo");
+        hiveShell.setHiveConfValue("location", "${hiveconf:hadoop.tmp.dir}/foo");
         hiveShell.addSetupScript("CREATE table FOO (s String) LOCATION '${hiveconf:location}'");
         OutputStream ros = hiveShell.getResourceOutputStream("${hiveconf:location}/foo.data");
 

--- a/src/test/java/com/klarna/hiverunner/CtasTest.java
+++ b/src/test/java/com/klarna/hiverunner/CtasTest.java
@@ -28,7 +28,7 @@ import java.util.List;
 @RunWith(StandaloneHiveRunner.class)
 public class CtasTest {
 
-    @HiveResource(targetFile = "${hiveconf:hive.vs}/foo/data.csv")
+    @HiveResource(targetFile = "${hiveconf:hadoop.tmp.dir}/foo/data.csv")
     private String data = "A,B\nC,D\nE,F";
 
     @HiveSQL(files = {"ctasTest/ctas.sql"})

--- a/src/test/java/com/klarna/hiverunner/HiveRunnerAnnotationsTest.java
+++ b/src/test/java/com/klarna/hiverunner/HiveRunnerAnnotationsTest.java
@@ -58,13 +58,13 @@ public class HiveRunnerAnnotationsTest {
     @HiveSQL(files = {"hiveRunnerAnnotationsTest/hql1.sql"}, autoStart = false)
     private HiveShell hiveShell;
 
-    @HiveResource(targetFile = "${hiveconf:hive.vs}/foo/fromString.csv")
+    @HiveResource(targetFile = "${hiveconf:hadoop.tmp.dir}/foo/fromString.csv")
     public String dataFromString = "1,B\n2,D\nE,F";
 
-    @HiveResource(targetFile = "${hiveconf:hive.vs}/foo/fromFile.csv")
+    @HiveResource(targetFile = "${hiveconf:hadoop.tmp.dir}/foo/fromFile.csv")
     public File dataFromFile = new File(ClassLoader.getSystemResource("hiveRunnerAnnotationsTest/testData.csv").getPath());
 
-    @HiveResource(targetFile = "${hiveconf:hive.vs}/foo/fromPath.csv")
+    @HiveResource(targetFile = "${hiveconf:hadoop.tmp.dir}/foo/fromPath.csv")
     public Path dataFromPath = Paths.get(ClassLoader.getSystemResource("hiveRunnerAnnotationsTest/testData2.csv").getPath());
 
     @Before

--- a/src/test/java/com/klarna/hiverunner/PartitionSupportTest.java
+++ b/src/test/java/com/klarna/hiverunner/PartitionSupportTest.java
@@ -46,7 +46,7 @@ public class PartitionSupportTest {
     @HiveProperties
     public Map<String, String> hiveProperties = MapUtils.putAll(new HashMap(), new String[]{
             "table.name", tableName,
-            "HDFS_ROOT_FOO", "${hiveconf:hive.vs}"
+            "HDFS_ROOT_FOO", "${hiveconf:hadoop.tmp.dir}"
     });
 
     @HiveSQL(files = "partitionSupportTest/hql_example.sql")

--- a/src/test/java/com/klarna/hiverunner/ReservedKeywordTest.java
+++ b/src/test/java/com/klarna/hiverunner/ReservedKeywordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Klarna AB
+ * Copyright 2016 Klarna AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/klarna/hiverunner/ReservedKeywordTest.java
+++ b/src/test/java/com/klarna/hiverunner/ReservedKeywordTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2013 Klarna AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.klarna.hiverunner;
+
+import com.klarna.hiverunner.annotations.HiveSQL;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@RunWith(StandaloneHiveRunner.class)
+public class ReservedKeywordTest {
+
+    @HiveSQL(files = {}, autoStart = false)
+    private HiveShell hiveShell;
+
+
+    /**
+     * As of Hive 1.2 there are a number of new reserved keywords, e.g. date, timestamp and update.
+     * This test verifies that we still can have backwards compatibility by setting the HiveConf
+     * 'hive.support.sql11.reserved.keywords' to false.
+     */
+    @Test
+    public void reservedKeywordsShouldBeAllowedWhenHiveConfIsSet() throws IOException {
+
+        hiveShell.setHiveConfValue("hive.support.sql11.reserved.keywords", "false");
+        hiveShell.addSetupScript("CREATE table FOO (date String, `timestamp` string, `update` string)");
+
+        hiveShell.start();
+
+    }
+
+    /**
+     * As of Hive 1.2 there are a number of new reserved keywords, e.g. date, timestamp and update.
+     * This test verifies that we still can use the identifier by adding a backtick quote.
+     */
+    @Test
+    public void reservedKeywordsShouldBeAllowedWhenIdentifierHasBacktickQuote() throws IOException {
+
+        hiveShell.addSetupScript("CREATE table FOO (`date` String, `timestamp` string, `update` string)");
+
+        hiveShell.start();
+
+    }
+}

--- a/src/test/java/com/klarna/hiverunner/ReservedKeywordTest.java
+++ b/src/test/java/com/klarna/hiverunner/ReservedKeywordTest.java
@@ -43,7 +43,7 @@ public class ReservedKeywordTest {
     public void reservedKeywordsShouldBeAllowedWhenHiveConfIsSet() throws IOException {
 
         hiveShell.setHiveConfValue("hive.support.sql11.reserved.keywords", "false");
-        hiveShell.addSetupScript("CREATE table FOO (date String, `timestamp` string, `update` string)");
+        hiveShell.addSetupScript("CREATE table FOO (date String, timestamp string, update string)");
 
         hiveShell.start();
 

--- a/src/test/java/com/klarna/hiverunner/SetPropertyTest.java
+++ b/src/test/java/com/klarna/hiverunner/SetPropertyTest.java
@@ -30,12 +30,12 @@ public class SetPropertyTest {
     @Test(expected = IllegalStateException.class)
     public void propertyShouldNotBeSetIfShellIsAlreadyStarted() {
         shell.start();
-        shell.setProperty("foo", "bar");
+        shell.setHiveConfValue("foo", "bar");
     }
 
     @Test
     public void propertyShouldBeSetInHiveConfiguration() {
-        shell.setProperty("foo", "bar");
+        shell.setHiveConfValue("foo", "bar");
         shell.start();
         Assert.assertEquals("bar", shell.getHiveConf().get("foo"));
     }

--- a/src/test/java/com/klarna/hiverunner/ToUpperCaseSerDe.java
+++ b/src/test/java/com/klarna/hiverunner/ToUpperCaseSerDe.java
@@ -17,7 +17,7 @@
 package com.klarna.hiverunner;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.serde.Constants;
+import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.AbstractSerDe;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.SerDeStats;
@@ -38,7 +38,7 @@ public class ToUpperCaseSerDe extends AbstractSerDe {
 
     @Override
     public void initialize(Configuration configuration, Properties properties) throws SerDeException {
-        columns = Arrays.asList(((String) properties.get(Constants.LIST_COLUMNS)).split(","));
+        columns = Arrays.asList(((String) properties.get(serdeConstants.LIST_COLUMNS)).split(","));
     }
 
     @Override

--- a/src/test/java/com/klarna/hiverunner/config/HiveRunnerConfigTest.java
+++ b/src/test/java/com/klarna/hiverunner/config/HiveRunnerConfigTest.java
@@ -37,12 +37,6 @@ public class HiveRunnerConfigTest {
     }
 
     @Test
-    public void testDefaultHiveExecutionEngine() {
-        HiveRunnerConfig config = new HiveRunnerConfig();
-        Assert.assertEquals("mr", config.getHiveExecutionEngine());
-    }
-
-    @Test
     public void testEnableTimeout() {
         Properties sysProps = new Properties();
         sysProps.put(HiveRunnerConfig.ENABLE_TIMEOUT_PROPERTY_NAME,

--- a/src/test/resources/ctasTest/ctas.sql
+++ b/src/test/resources/ctasTest/ctas.sql
@@ -1,7 +1,7 @@
 CREATE EXTERNAL TABLE foo (s1 string, s2 string)
   ROW FORMAT DELIMITED FIELDS TERMINATED BY ','
   STORED AS TEXTFILE
-  LOCATION '${hiveconf:hive.vs}/foo/';
+  LOCATION '${hiveconf:hadoop.tmp.dir}/foo/';
 
 
 CREATE TABLE foo_prim as select * from foo;

--- a/src/test/resources/hiveRunnerAnnotationsTest/hql1.sql
+++ b/src/test/resources/hiveRunnerAnnotationsTest/hql1.sql
@@ -1,4 +1,4 @@
 CREATE EXTERNAL TABLE foo (s1 int, s2 string)
   ROW FORMAT DELIMITED FIELDS TERMINATED BY ','
   STORED AS TEXTFILE
-  LOCATION '${hiveconf:hive.vs}/foo/';
+  LOCATION '${hiveconf:hadoop.tmp.dir}/foo/';


### PR DESCRIPTION
We need to upgrade HiveRunner to use Hive 1.2.

Most things are backward compatible, but there are some new reserved keywords in Hive that might cause some issues. Thus we need to bump the major version of HiveRunner as well.

There are no big changes, I basically just changed the dependency and removed some unused Hive properties and changes some deprecated usage.

I also added a maven profile so that we can run the test suite using Tez.