### PR TITLE
squid:S2293 - The diamond operator ('<>') should be used

### DIFF
--- a/src/main/java/com/klarna/hiverunner/StandaloneHiveRunner.java
+++ b/src/main/java/com/klarna/hiverunner/StandaloneHiveRunner.java
@@ -99,7 +99,7 @@ public class StandaloneHiveRunner extends BlockJUnit4ClassRunner {
          *  Note that rules will be executed in reverse order to how they're added.
          */
 
-        List<TestRule> rules = new ArrayList<TestRule>();
+        List<TestRule> rules = new ArrayList<>();
         rules.addAll(super.getTestRules(target));
         rules.add(hiveRunnerRule);
         rules.add(testBaseDir);
@@ -234,7 +234,7 @@ public class StandaloneHiveRunner extends BlockJUnit4ClassRunner {
             Preconditions.checkState(fields.size() == 1, "Exact one field should to be annotated with @HiveSQL");
 
             final Field field = fields.iterator().next();
-            List<Path> scripts = new ArrayList<Path>();
+            List<Path> scripts = new ArrayList<>();
             HiveSQL annotation = field.getAnnotation(HiveSQL.class);
             for (String scriptFilePath : annotation.files()) {
                 Path file = Paths.get(Resources.getResource(scriptFilePath).toURI());

--- a/src/main/java/com/klarna/hiverunner/builder/HiveShellBuilder.java
+++ b/src/main/java/com/klarna/hiverunner/builder/HiveShellBuilder.java
@@ -34,11 +34,11 @@ import java.util.Map;
  * Builds a HiveShell.
  */
 public class HiveShellBuilder {
-    private List<String> scriptsUnderTest = new ArrayList<String>();
-    private Map<String, String> props = new HashMap<String, String>();
+    private List<String> scriptsUnderTest = new ArrayList<>();
+    private Map<String, String> props = new HashMap<>();
     private HiveServerContainer hiveServerContainer;
-    private List<HiveResource> resources = new ArrayList<HiveResource>();
-    private List<String> setupScripts = new ArrayList<String>();
+    private List<HiveResource> resources = new ArrayList<>();
+    private List<String> setupScripts = new ArrayList<>();
     private CommandShellEmulation commandShellEmulation = CommandShellEmulation.HIVE_CLI;
 
     public void setHiveServerContainer(HiveServerContainer hiveServerContainer) {

--- a/src/test/java/com/klarna/hiverunner/ToUpperCaseSerDe.java
+++ b/src/test/java/com/klarna/hiverunner/ToUpperCaseSerDe.java
@@ -62,7 +62,7 @@ public class ToUpperCaseSerDe extends AbstractSerDe {
         // Constructing the row ObjectInspector:
         // The row consists of some string columns, each column will be a java
         // String object.
-        List<ObjectInspector> columnOIs = new ArrayList<ObjectInspector>(columns.size());
+        List<ObjectInspector> columnOIs = new ArrayList<>(columns.size());
 
         for (int i = 0; i < columns.size(); i++) {
             columnOIs.add(PrimitiveObjectInspectorFactory.javaStringObjectInspector);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - The diamond operator ('<>') should be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2293

Please let me know if you have any questions.

M-Ezzat