### PR TITLE
squid:S1312, squid:UnusedPrivateMethod - Loggers should be "private s…

### DIFF
--- a/src/main/java/com/klarna/hiverunner/HiveServerContainer.java
+++ b/src/main/java/com/klarna/hiverunner/HiveServerContainer.java
@@ -43,7 +43,7 @@ import java.util.Map;
  */
 public class HiveServerContainer {
 
-    private final Logger LOGGER = LoggerFactory.getLogger(HiveServerContainer.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HiveServerContainer.class);
 
     private CLIService client;
     private final HiveServerContext context;

--- a/src/main/java/com/klarna/hiverunner/StandaloneHiveServerContext.java
+++ b/src/main/java/com/klarna/hiverunner/StandaloneHiveServerContext.java
@@ -223,14 +223,6 @@ public class StandaloneHiveServerContext implements HiveServerContext {
         }
     }
 
-    private File newFile(TemporaryFolder basedir, String fileName) {
-        try {
-            return basedir.newFile(fileName);
-        } catch (IOException e) {
-            throw new IllegalStateException("Failed to create tmp file: " + e.getMessage(), e);
-        }
-    }
-
     public HiveConf getHiveConf() {
         return hiveConf;
     }

--- a/src/main/java/com/klarna/hiverunner/builder/HiveShellBase.java
+++ b/src/main/java/com/klarna/hiverunner/builder/HiveShellBase.java
@@ -47,7 +47,7 @@ import java.util.Map;
  * HiveShell implementation delegating to HiveServerContainer
  */
 class HiveShellBase implements HiveShell {
-    private final static Logger logger = LoggerFactory.getLogger(HiveShellBase.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HiveShellBase.class);
 
     protected boolean started = false;
 
@@ -275,7 +275,7 @@ class HiveShellBase implements HiveShell {
 
     private void executeSetupScripts() {
         for (String setupScript : setupScripts) {
-            logger.debug("Executing script: " + setupScript);
+            LOGGER.debug("Executing script: " + setupScript);
             executeScriptWithCommandShellEmulation(setupScript);
         }
     }
@@ -301,7 +301,7 @@ class HiveShellBase implements HiveShell {
                                 + e.getMessage(), e);
             }
 
-            logger.debug("Created hive resource " + targetFile);
+            LOGGER.debug("Created hive resource " + targetFile);
 
         }
     }

--- a/src/main/java/com/klarna/hiverunner/config/HiveRunnerConfig.java
+++ b/src/main/java/com/klarna/hiverunner/config/HiveRunnerConfig.java
@@ -172,14 +172,6 @@ public class HiveRunnerConfig {
         this.hiveConfSystemOverride.putAll(hiveRunnerConfig.hiveConfSystemOverride);
     }
 
-    private String load(String property, String defaultValue,
-                        List<String> validValues, Properties sysProperties) {
-        String value = load(property, defaultValue, sysProperties);
-        Preconditions.checkArgument(validValues.contains(value),
-                "Invalid value of system property '" + property + "': Only values '" + validValues + "' are allowed");
-        return value;
-    }
-
     private static boolean load(String property, boolean defaultValue, Properties sysProperties) {
         String value = sysProperties.getProperty(property);
         return value == null ? defaultValue : Boolean.parseBoolean(value);

--- a/src/test/java/com/klarna/hiverunner/NeverEndingUdf.java
+++ b/src/test/java/com/klarna/hiverunner/NeverEndingUdf.java
@@ -10,7 +10,7 @@ import java.security.SecureRandom;
 
 public class NeverEndingUdf extends UDF {
 
-    private final Logger LOGGER = LoggerFactory.getLogger(this.getClass());
+    private static final Logger LOGGER = LoggerFactory.getLogger(NeverEndingUdf.class);
 
     public Text evaluate(Text value) {
         LOGGER.warn("Entering infinite loop");

--- a/src/test/java/com/klarna/hiverunner/SlowlyFailingUdf.java
+++ b/src/test/java/com/klarna/hiverunner/SlowlyFailingUdf.java
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory;
 
 public class SlowlyFailingUdf extends UDF {
 
-    private final Logger LOGGER = LoggerFactory.getLogger(this.getClass());
+    private static final Logger LOGGER = LoggerFactory.getLogger(SlowlyFailingUdf.class);
 
 
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S1312 - Loggers should be "private static final" and should share a naming convention
squid:UnusedPrivateMethod - Unused private method should be removed

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1312
https://dev.eclipse.org/sonar/coding_rules#q=squid:UnusedPrivateMethod

Please let me know if you have any questions.

M-Ezzat