### PR TITLE
Change visibility of classes in order to create a Hive shell for testing

### DIFF
--- a/src/main/java/com/klarna/hiverunner/HiveServerContainer.java
+++ b/src/main/java/com/klarna/hiverunner/HiveServerContainer.java
@@ -51,7 +51,7 @@ public class HiveServerContainer {
     private HiveServer2 hiveServer2;
     private SessionState currentSessionState;
 
-    HiveServerContainer(HiveServerContext context) {
+    public HiveServerContainer(HiveServerContext context) {
         this.context = context;
     }
 

--- a/src/main/java/com/klarna/hiverunner/StandaloneHiveServerContext.java
+++ b/src/main/java/com/klarna/hiverunner/StandaloneHiveServerContext.java
@@ -53,7 +53,7 @@ public class StandaloneHiveServerContext implements HiveServerContext {
     private final TemporaryFolder basedir;
     private final HiveRunnerConfig hiveRunnerConfig;
 
-    StandaloneHiveServerContext(TemporaryFolder basedir, HiveRunnerConfig hiveRunnerConfig) {
+    public StandaloneHiveServerContext(TemporaryFolder basedir, HiveRunnerConfig hiveRunnerConfig) {
         this.basedir = basedir;
         this.hiveRunnerConfig = hiveRunnerConfig;
     }


### PR DESCRIPTION
Hi,

I believe this is an ongoing conversation already but this is the actual fix for enabling the creation of a Hive Shell from outside HiveRunner. We would like to have some Cucumber tests using HiveRunner but we need to use Cucumber runner annotation so we chose to create a Hive shell manually and execute required scripts.