### PR TITLE
squid:S1943 - Classes and methods that rely on the default system enc…

### DIFF
--- a/src/main/java/com/klarna/hiverunner/StandaloneHiveRunner.java
+++ b/src/main/java/com/klarna/hiverunner/StandaloneHiveRunner.java
@@ -47,6 +47,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -291,7 +292,7 @@ public class StandaloneHiveRunner extends BlockJUnit4ClassRunner {
 
     private static String readAll(Path path) {
         try {
-            return new String(Files.readAllBytes(path));
+            return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new IllegalStateException("Unable to read " + path + ": " + e.getMessage(), e);
         }

--- a/src/main/java/com/klarna/hiverunner/builder/HiveResource.java
+++ b/src/main/java/com/klarna/hiverunner/builder/HiveResource.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -39,7 +40,7 @@ class HiveResource {
     }
 
     HiveResource(String targetFile, String data) throws IOException {
-        this(targetFile, createOutputStream(data.getBytes()));
+        this(targetFile, createOutputStream(data.getBytes(StandardCharsets.UTF_8)));
     }
 
     private HiveResource(String targetFile, ByteArrayOutputStream byteArrayOutputStream) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1943 - Classes and methods that rely on the default system encoding should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943

Please let me know if you have any questions.

M-Ezzat