### PR TITLE
Provide a means to test scripts with non-table output

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ Future work and Limitations
 Change Log (From version 2.2.0 and onwards)
 ==============
 
+### __TBD__
+* Added methods to the shell that allow statements contained in files to be executed and their results gathered. These are particularly useful for HQL scripts that generate no table based data and instead write results to STDOUT. In practice we've seen these scripts used in data processing job orchestration scripts (e.g `bash`) to check for new data, calculate processing boundaries, etc. These values are then used to appropriately configure and launch some downstream job.    
+
 ### __3.0.0__
 
 * Upgraded to Hive 1.2.1 (Note: new major release with backwards incompatibility issues). As of Hive 1.2 there are a number of new reserved keywords, see [DDL manual](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-Keywords,Non-reservedKeywordsandReservedKeywords) for more information. 

--- a/src/main/java/com/klarna/hiverunner/HiveShell.java
+++ b/src/main/java/com/klarna/hiverunner/HiveShell.java
@@ -161,7 +161,7 @@ public interface HiveShell {
      * Set a HiveConf property.
      * <p/>
      * May only be called pre #start()
-     * @Deprecated Use {@link HiveShell#setHiveConfValue(String, String)} intstead
+     * @Deprecated Use {@link HiveShell#setHiveConfValue(String, String)} instead
      */
     @Deprecated
     void setProperty(String key, String value);

--- a/src/main/java/com/klarna/hiverunner/HiveShell.java
+++ b/src/main/java/com/klarna/hiverunner/HiveShell.java
@@ -49,6 +49,62 @@ public interface HiveShell {
     List<String> executeQuery(String hql, String rowValuesDelimitedBy, String replaceNullWith);
 
     /**
+     * Executes a single query from a script file, returning any results.
+     * <p/>
+     * May only be called post #start()
+     */
+    List<String> executeQuery(File script);
+    
+    /**
+     * Executes a single query from a script file, returning any results.
+     * <p/>
+     * May only be called post #start()
+     */
+    List<String> executeQuery(Path script);
+    
+    /**
+     * Executes a single query from a script file, returning any results.
+     * <p/>
+     * May only be called post #start()
+     */
+    List<String> executeQuery(Charset charset, File script);
+    
+    /**
+     * Executes a single query from a script file, returning any results.
+     * <p/>
+     * May only be called post #start()
+     */
+    List<String> executeQuery(Charset charset, Path script);
+    
+    /**
+     * Executes a single query from a script file, returning any results.
+     * <p/>
+     * May only be called post #start()
+     */
+    List<String> executeQuery(File script, String rowValuesDelimitedBy, String replaceNullWith);
+    
+    /**
+     * Executes a single query from a script file, returning any results.
+     * <p/>
+     * May only be called post #start()
+     */
+    List<String> executeQuery(Path script, String rowValuesDelimitedBy, String replaceNullWith);
+    
+    /**
+     * Executes a single query from a script file, returning any results.
+     * <p/>
+     * May only be called post #start()
+     */
+    List<String> executeQuery(Charset charset, File script, String rowValuesDelimitedBy, String replaceNullWith);
+    
+    /**
+     * Executes a single query from a script file, returning any results.
+     * <p/>
+     * May only be called post #start()
+     */
+    List<String> executeQuery(Charset charset, Path script, String rowValuesDelimitedBy, String replaceNullWith);
+    
+    /**
      * Execute a single hive query
      * <p/>
      * May only be called post #start()

--- a/src/main/java/com/klarna/hiverunner/builder/HiveShellBase.java
+++ b/src/main/java/com/klarna/hiverunner/builder/HiveShellBase.java
@@ -379,17 +379,17 @@ class HiveShellBase implements HiveShell {
 
 	@Override
 	public List<String> executeQuery(Charset charset, File script) {
-		return executeQuery(charset, Paths.get(script.toURI()));
+		return executeQuery(charset, script, DEFAULT_ROW_VALUE_DELIMTER, DEFAULT_NULL_REPRESENTATION);
 	}
 
 	@Override
 	public List<String> executeQuery(Charset charset, Path script) {
-		return executeQuery(script, DEFAULT_ROW_VALUE_DELIMTER, DEFAULT_NULL_REPRESENTATION);
+		return executeQuery(charset, script, DEFAULT_ROW_VALUE_DELIMTER, DEFAULT_NULL_REPRESENTATION);
 	}
 
 	@Override
 	public List<String> executeQuery(File script, String rowValuesDelimitedBy, String replaceNullWith) {
-		return executeQuery(Paths.get(script.toURI()), rowValuesDelimitedBy, replaceNullWith);
+		return executeQuery(Charset.defaultCharset(), script, rowValuesDelimitedBy, replaceNullWith);
 	}
 
 	@Override

--- a/src/test/java/com/klarna/hiverunner/ExecuteFileBasedScriptIntegrationTest.java
+++ b/src/test/java/com/klarna/hiverunner/ExecuteFileBasedScriptIntegrationTest.java
@@ -21,26 +21,26 @@ import com.klarna.hiverunner.annotations.HiveSQL;
 @RunWith(StandaloneHiveRunner.class)
 public class ExecuteFileBasedScriptIntegrationTest {
 
-	  @Rule
-	  public TemporaryFolder temp = new TemporaryFolder();
+      @Rule
+      public TemporaryFolder temp = new TemporaryFolder();
 
-	  @HiveSQL(files = {})
-	  private HiveShell hiveShell;
+      @HiveSQL(files = {})
+      private HiveShell hiveShell;
 
-	  @Test
-	  public void testExecuteFileBasedScript() throws IOException {
-	    File hqlScriptFile = temp.newFile("get_current_database.hql");
+      @Test
+      public void testExecuteFileBasedScript() throws IOException {
+        File hqlScriptFile = temp.newFile("get_current_database.hql");
 
-	    try (PrintStream out = new PrintStream(hqlScriptFile)) {
-	      out.println("select current_database(), NULL, 100;");
-	    }
+        try (PrintStream out = new PrintStream(hqlScriptFile)) {
+          out.println("select current_database(), NULL, 100;");
+        }
 
-	    hiveShell.execute(hqlScriptFile);
+        hiveShell.execute(hqlScriptFile);
 
-	    Charset optionalCharset = UTF_8;
-		List<String> results = hiveShell.executeQuery(optionalCharset, hqlScriptFile, " optional_column_delimiter ", "optional_null_replacement");
-	    
-		assertThat(results.size(), is(1));
-		assertThat(results.get(0), is("default optional_column_delimiter optional_null_replacement optional_column_delimiter 100"));
-	  }
+        Charset optionalCharset = UTF_8;
+        List<String> results = hiveShell.executeQuery(optionalCharset, hqlScriptFile, " optional_column_delimiter ", "optional_null_replacement");
+        
+        assertThat(results.size(), is(1));
+        assertThat(results.get(0), is("default optional_column_delimiter optional_null_replacement optional_column_delimiter 100"));
+      }
 }

--- a/src/test/java/com/klarna/hiverunner/ExecuteFileBasedScriptIntegrationTest.java
+++ b/src/test/java/com/klarna/hiverunner/ExecuteFileBasedScriptIntegrationTest.java
@@ -1,0 +1,46 @@
+package com.klarna.hiverunner;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import static com.google.common.base.Charsets.UTF_8;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.Charset;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+
+import com.klarna.hiverunner.annotations.HiveSQL;
+
+@RunWith(StandaloneHiveRunner.class)
+public class ExecuteFileBasedScriptIntegrationTest {
+
+	  @Rule
+	  public TemporaryFolder temp = new TemporaryFolder();
+
+	  @HiveSQL(files = {})
+	  private HiveShell hiveShell;
+
+	  @Test
+	  public void testExecuteFileBasedScript() throws IOException {
+	    File hqlScriptFile = temp.newFile("get_current_database.hql");
+
+	    try (PrintStream out = new PrintStream(hqlScriptFile)) {
+	      out.println("select current_database(), NULL, 100;");
+	    }
+
+	    hiveShell.execute(hqlScriptFile);
+
+	    Charset optionalCharset = UTF_8;
+		List<String> results = hiveShell.executeQuery(optionalCharset, hqlScriptFile, " optional_column_delimiter ", "optional_null_replacement");
+	    
+		assertThat(results.size(), is(1));
+		assertThat(results.get(0), is("default optional_column_delimiter optional_null_replacement optional_column_delimiter 100"));
+	  }
+}

--- a/src/test/java/com/klarna/hiverunner/builder/HiveShellBaseTest.java
+++ b/src/test/java/com/klarna/hiverunner/builder/HiveShellBaseTest.java
@@ -193,8 +193,7 @@ public class HiveShellBaseTest {
 		File file = new File(tempFolder.getRoot(), "script.hql");
 		Files.write(hql, file, UTF_8);
 		
-		@SuppressWarnings("unused")
-		List<String> results = shell.executeQuery(UTF_8, Paths.get(file.toURI()), "xxx", "yyy");
+		shell.executeQuery(UTF_8, Paths.get(file.toURI()), "xxx", "yyy");
 	}
 
     private HiveShell createHiveShell(String... keyValues) {

--- a/src/test/java/com/klarna/hiverunner/builder/HiveShellBaseTest.java
+++ b/src/test/java/com/klarna/hiverunner/builder/HiveShellBaseTest.java
@@ -179,8 +179,7 @@ public class HiveShellBaseTest {
 		File file = new File(tempFolder.getRoot(), "script.hql");
 		Files.write(hql, file, UTF_8);
 		
-		@SuppressWarnings("unused")
-		List<String> results = shell.executeQuery(UTF_8, Paths.get(file.toURI()), "xxx", "yyy");
+		shell.executeQuery(UTF_8, Paths.get(file.toURI()), "xxx", "yyy");
 	}
 	
 	@Test(expected = IllegalArgumentException.class)

--- a/src/test/java/com/klarna/hiverunner/builder/HiveShellBaseTest.java
+++ b/src/test/java/com/klarna/hiverunner/builder/HiveShellBaseTest.java
@@ -161,7 +161,7 @@ public class HiveShellBaseTest {
 		when(container.executeStatement(statement)).thenReturn(Arrays.<Object[]> asList( new Object[] {"default", null, 100}));
 		String hql = statement + ";";
 
-		File file = new File(tempFolder.getRoot(), "script.hql");
+		File file = tempFolder.newFile("script.hql");
 		Files.write(hql, file, UTF_8);
 
 		List<String> results = shell.executeQuery(UTF_8, Paths.get(file.toURI()), "xxx", "yyy");

--- a/src/test/java/com/klarna/hiverunner/builder/HiveShellBaseTest.java
+++ b/src/test/java/com/klarna/hiverunner/builder/HiveShellBaseTest.java
@@ -2,7 +2,11 @@ package com.klarna.hiverunner.builder;
 
 import com.klarna.hiverunner.CommandShellEmulation;
 import static com.google.common.base.Charsets.UTF_8;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.common.io.Files;
 import com.klarna.hiverunner.HiveServerContainer;
@@ -147,6 +151,51 @@ public class HiveShellBaseTest {
       HiveShell shell = createHiveShell();
       shell.execute(UTF_8, Paths.get(file.toURI()));
     }
+    
+	@Test
+	public void executeQueryFromFile() throws IOException {
+		HiveShell shell = createHiveShell();
+		shell.start();
+
+		String statement = "select current_database(), NULL, 100";
+		when(container.executeStatement(statement)).thenReturn(Arrays.<Object[]> asList( new Object[] {"default", null, 100}));
+		String hql = statement + ";";
+
+		File file = new File(tempFolder.getRoot(), "script.hql");
+		Files.write(hql, file, UTF_8);
+
+		List<String> results = shell.executeQuery(UTF_8, Paths.get(file.toURI()), "xxx", "yyy");
+		assertThat(results.size(), is(1));
+		assertThat(results.get(0), is("defaultxxxyyyxxx100"));
+	}
+	
+	@Test(expected = IllegalArgumentException.class)
+	public void executeQueryFromFileMoreThanOneStatement() throws IOException {
+		HiveShell shell = createHiveShell();
+		shell.start();
+		
+		String hql = "use default;\nselect current_database(), NULL, 100;";
+		
+		File file = new File(tempFolder.getRoot(), "script.hql");
+		Files.write(hql, file, UTF_8);
+		
+		@SuppressWarnings("unused")
+		List<String> results = shell.executeQuery(UTF_8, Paths.get(file.toURI()), "xxx", "yyy");
+	}
+	
+	@Test(expected = IllegalArgumentException.class)
+	public void executeQueryFromFileZeroStatements() throws IOException {
+		HiveShell shell = createHiveShell();
+		shell.start();
+		
+		String hql = "";
+		
+		File file = new File(tempFolder.getRoot(), "script.hql");
+		Files.write(hql, file, UTF_8);
+		
+		@SuppressWarnings("unused")
+		List<String> results = shell.executeQuery(UTF_8, Paths.get(file.toURI()), "xxx", "yyy");
+	}
 
     private HiveShell createHiveShell(String... keyValues) {
         Map<String, String> hiveConf = MapUtils.putAll(new HashMap(), keyValues);


### PR DESCRIPTION
It is currently possible to create perfectly valid HQL scripts that cannot not be directly tested using HiveRunner. Such script files contain a statement that produces data to STDOUT and not a new table as is typically the case. They are typically found in situation where the output is used to drive a bash script that invokes some other data processing. While there are workarounds, this pull requests adds the functionality to the `HiveShell`, simplifying the HiveRunner user experience.

Contrived script that cannot be readily tested currently:

    select current_database();

If the above query is contained in a `.hql` file, to be invoked as part of some batch process, there is no means in the current HiveRunner API to both execute the statement contained in the file and simultaneously capture the results so that assertions can be applied.
