### PR TITLE
Case insensitive bug fix

### DIFF
--- a/src/main/java/com/klarna/hiverunner/data/TableDataBuilder.java
+++ b/src/main/java/com/klarna/hiverunner/data/TableDataBuilder.java
@@ -36,8 +36,11 @@ class TableDataBuilder {
   private List<String> names;
 
   TableDataBuilder(HCatTable table) {
-    schema = new HCatSchema(
-        ImmutableList.<HCatFieldSchema> builder().addAll(table.getCols()).addAll(table.getPartCols()).build());
+    schema = new HCatSchema(ImmutableList
+        .<HCatFieldSchema> builder()
+        .addAll(table.getCols())
+        .addAll(table.getPartCols())
+        .build());
     partitionColumns = table.getPartCols();
     withAllColumns();
   }
@@ -132,15 +135,8 @@ class TableDataBuilder {
     try {
       converted = Converters.convert(value, typeInfo);
     } catch (ConversionException e) {
-      throw new IllegalArgumentException("Invalid value for "
-          + name
-          + ". Got '"
-          + value
-          + "' ("
-          + value.getClass().getSimpleName()
-          + "). Expected "
-          + typeInfo.getTypeName()
-          + ".", e);
+      throw new IllegalArgumentException("Invalid value for " + name + ". Got '" + value + "' ("
+          + value.getClass().getSimpleName() + "). Expected " + typeInfo.getTypeName() + ".", e);
     }
     try {
       row.set(name, schema, converted);

--- a/src/main/java/com/klarna/hiverunner/data/TsvFileParser.java
+++ b/src/main/java/com/klarna/hiverunner/data/TsvFileParser.java
@@ -63,7 +63,7 @@ public class TsvFileParser implements FileParser {
    * Enable if TSV file has header row. Default is false.
    */
   public TsvFileParser withHeader() {
-    this.hasHeader = true;
+    hasHeader = true;
     return this;
   }
 
@@ -71,17 +71,16 @@ public class TsvFileParser implements FileParser {
    * Enable if TSV file has header row. Default is false.
    */
   public TsvFileParser withoutHeader() {
-    this.hasHeader = false;
+    hasHeader = false;
     return this;
   }
-
 
   @Override
   public List<Object[]> parse(File file, HCatSchema schema, List<String> names) {
     try {
       List<String> lines = Files.readAllLines(file.toPath(), charset);
 
-      if (this.hasHeader) {
+      if (hasHeader) {
         lines = lines.subList(1, lines.size());
       }
 
@@ -97,7 +96,7 @@ public class TsvFileParser implements FileParser {
 
   @Override
   public boolean hasColumnNames() {
-    return this.hasHeader;
+    return hasHeader;
   }
 
   @Override
@@ -112,7 +111,7 @@ public class TsvFileParser implements FileParser {
         columns.add(column);
       }
       return columns;
-    } catch(IOException e) {
+    } catch (IOException e) {
       throw new RuntimeException("Error while reading file", e);
     }
   }

--- a/src/main/java/com/klarna/hiverunner/data/TsvFileParser.java
+++ b/src/main/java/com/klarna/hiverunner/data/TsvFileParser.java
@@ -63,7 +63,7 @@ public class TsvFileParser implements FileParser {
    * Enable if TSV file has header row. Default is false.
    */
   public TsvFileParser withHeader() {
-    hasHeader = true;
+    this.hasHeader = true;
     return this;
   }
 
@@ -71,16 +71,17 @@ public class TsvFileParser implements FileParser {
    * Enable if TSV file has header row. Default is false.
    */
   public TsvFileParser withoutHeader() {
-    hasHeader = false;
+    this.hasHeader = false;
     return this;
   }
+
 
   @Override
   public List<Object[]> parse(File file, HCatSchema schema, List<String> names) {
     try {
       List<String> lines = Files.readAllLines(file.toPath(), charset);
 
-      if (hasHeader) {
+      if (this.hasHeader) {
         lines = lines.subList(1, lines.size());
       }
 
@@ -96,7 +97,7 @@ public class TsvFileParser implements FileParser {
 
   @Override
   public boolean hasColumnNames() {
-    return hasHeader;
+    return this.hasHeader;
   }
 
   @Override
@@ -111,7 +112,7 @@ public class TsvFileParser implements FileParser {
         columns.add(column);
       }
       return columns;
-    } catch (IOException e) {
+    } catch(IOException e) {
       throw new RuntimeException("Error while reading file", e);
     }
   }

--- a/src/test/java/com/klarna/hiverunner/data/TableDataBuilderTest.java
+++ b/src/test/java/com/klarna/hiverunner/data/TableDataBuilderTest.java
@@ -1,7 +1,11 @@
 package com.klarna.hiverunner.data;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -17,9 +21,14 @@ import org.apache.hive.hcatalog.common.HCatException;
 import org.apache.hive.hcatalog.data.HCatRecord;
 import org.apache.hive.hcatalog.data.schema.HCatFieldSchema;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import com.google.common.collect.Multimap;
 
+@RunWith(MockitoJUnitRunner.class)
 public class TableDataBuilderTest {
 
   private static final String DATABASE_NAME = "test_db";
@@ -41,6 +50,22 @@ public class TableDataBuilderTest {
     HCatTable table = table().cols(columns(COLUMN_1));
 
     new TableDataBuilder(table).set("unknown_column", "value");
+  }
+
+  @Mock
+  private TsvFileParser tsvFileParser;
+
+  @Test
+  public void testAddRowsFromWithMixedCaseColumnNames() {
+    File file = new File("");
+    HCatTable table = table().cols(columns("COLUMN_1", "coLUMN_2", "column_3"));
+    TableDataBuilder tableDataBuilder = Mockito.spy(new TableDataBuilder(table));
+
+    when(tsvFileParser.hasColumnNames()).thenReturn(true);
+    when(tsvFileParser.getColumnNames(file)).thenReturn(Arrays.asList("COLUMN_1", "coLUMN_2", "column_3"));
+
+    tableDataBuilder.addRowsFrom(file, tsvFileParser);
+    verify(tableDataBuilder, times(1)).withColumns("column_1", "column_2", "column_3");
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
* There was a bug which meant that if a file contained an uppercase letter in the column name, it wouldn't register that it was the same name as the column in the table to add to. 
* Fixed this by converting the names from the file to lower case when they are read in. 