### PR TITLE
Change Hive version from 2.3.3 to 2.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [4.1.0] - 2019-02-27
+## [4.1.1] - 2019-04-30
+### Changed
+- Default supported Hive version is now 2.3.4 (was 2.3.3).
+-- Version 2.3.3 has a vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2018-1314
 
+## [4.1.0] - 2019-02-27
 ### Changed
 - Internal refactoring to support upcoming "Mutant Swarm" project which provides unit test coverage for Hive SQL scripts. See [#65](https://github.com/klarna/HiveRunner/issues/65).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [4.1.1] - 2019-04-30
+## [4.1.1] - TBD
 ### Changed
-- Default supported Hive version is now 2.3.4 (was 2.3.3).
--- Version 2.3.3 has a vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2018-1314
+- Default supported Hive version is now 2.3.4 (was 2.3.3) as version 2.3.3 has a [vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2018-1314).
 
 ## [4.1.0] - 2019-02-27
 ### Changed

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ The [HiveShell](/src/main/java/com/klarna/hiverunner/HiveShell.java) field annot
 
 # Hive version compatibility
 
-- This version of HiveRunner is built for Hive 2.3.3.
+- This version of HiveRunner is built for Hive 2.3.4.
 - Command shell emulations are provided to closely match the behaviour of both the Hive CLI and Beeline interactive shells. The desired emulation can be specified in your `pom.xml` file like so: 
 
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <tez.version>0.9.1</tez.version>
-    <hive.version>2.3.3</hive.version>
+    <hive.version>2.3.4</hive.version>
     <license.maven.plugin.version>3.0</license.maven.plugin.version>
     <hive.execution.engine>mr</hive.execution.engine>
   </properties>


### PR DESCRIPTION
2.3.3 has a jdbc vulnerability. Upgrading to 2.3.4

https://nvd.nist.gov/vuln/detail/CVE-2018-1314