### PR TITLE
Fix NPE in StandaloneHiveRunner tearDown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [5.2.1] - TBD
+### Fixed
+- NullPointerException in tearDown of `StandaloneHiveRunner`.
+
 ## [5.2.0] - 2020-04-23
 ### Changed
 - Upgraded Hive version to 2.3.7 (was 2.3.6) (allows HiveRunner to be used on JDK>=9).

--- a/src/main/java/com/klarna/hiverunner/StandaloneHiveRunner.java
+++ b/src/main/java/com/klarna/hiverunner/StandaloneHiveRunner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2019 Klarna AB
+ * Copyright (C) 2013-2020 Klarna AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -171,7 +171,9 @@ public class StandaloneHiveRunner extends BlockJUnit4ClassRunner {
 
     private void tearDown(){
         tearDownContainer();
-        deleteTempFolder(container.getBaseDir());
+        if (container != null) {
+          deleteTempFolder(container.getBaseDir());
+        }
     }
 
     private void tearDownContainer(){


### PR DESCRIPTION
The code fixed here throws an NPE when used in an external project. I sadly couldn't reproduce it within HiveRunner itself.