### PR TITLE
Removed shaded jar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [6.0.1] - 2020-09-04
+## [6.0.1] - 2020-09-07
 ### Removed
 - Removed shaded jar that was being produced as a side-effect.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.0.1] - 2020-09-04
+### Removed
+- Removed shaded jar that was being produced as a side-effect.
+
 ## [6.0.0] - 2020-09-03
 ### Changed
 - Upgraded Hive version to 3.1.2 (was 2.3.7).

--- a/pom.xml
+++ b/pom.xml
@@ -255,39 +255,6 @@
         </configuration>
       </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>3.1.1</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <shadedArtifactAttached>true</shadedArtifactAttached>
-              <createDependencyReducedPom>false</createDependencyReducedPom>
-              <relocations>
-                <relocation>
-                  <pattern>org.apache.zookeeper.server</pattern>
-                  <shadedPattern>shaded.org.apache.zookeeper.server</shadedPattern>
-                </relocation>
-              </relocations>
-              <filters>
-                  <filter>
-                      <artifact>*:*</artifact>
-                      <excludes>
-                          <exclude>META-INF/*.SF</exclude>
-                          <exclude>META-INF/*.DSA</exclude>
-                          <exclude>META-INF/*.RSA</exclude>
-                      </excludes>
-                  </filter>
-              </filters>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
As part of the changes to move HiveRunner to support Hive 3, #93 was merged in which produces a 195MB shaded jar. I have tested HiveRunner 6.0.0 in two downstream projects using the main, unshaded HiveRunner artifact and they appear to work fine. So I propose we remove this jar file.