### PR TITLE
Fix bug for MS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [5.2.2] - TBD
+### Fixed
+- Fixed bug that appears in [Mutant Swarm](https://github.com/HotelsDotCom/mutant-swarm/pull/18/files) when updating HiveRunner to 5.2.1.
+
 ## [5.2.1] - 2020-05-27
 ### Fixed
 - NullPointerException in tearDown of `StandaloneHiveRunner`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [5.2.2] - TBD
 ### Fixed
-- Fixed bug that appears in [Mutant Swarm](https://github.com/HotelsDotCom/mutant-swarm/pull/18/files) when updating HiveRunner to 5.2.1.
+- Fixed bug that appears in [Mutant Swarm](https://github.com/HotelsDotCom/mutant-swarm/pull/18/files) when updating HiveRunner to version 5.2.1.
 
 ## [5.2.1] - 2020-05-27
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.klarna</groupId>
   <artifactId>hiverunner</artifactId>
-  <version>5.2.1</version>
+  <version>5.2.2-SNAPSHOT</version>
   <name>HiveRunner</name>
   <description>HiveRunner is a unit test framework based on JUnit (4 or 5) that enables TDD development of Hive SQL without the need of any installed dependencies.</description>
   <url>https://github.com/klarna/HiveRunner</url>

--- a/src/main/java/com/klarna/hiverunner/StandaloneHiveRunner.java
+++ b/src/main/java/com/klarna/hiverunner/StandaloneHiveRunner.java
@@ -39,6 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
@@ -156,18 +157,23 @@ public class StandaloneHiveRunner extends BlockJUnit4ClassRunner {
      * Drives the unit test.
      */
     public HiveShellContainer evaluateStatement(List<? extends Script> scripts, Object target,
-        Path temporaryFolder, Statement base) throws Throwable {
-        container = null;
-        FileUtil.setPermission(temporaryFolder.toFile(), FsPermission.getDirDefault());
-        try {
-            LOGGER.info("Setting up {} in {}", getName(), temporaryFolder.getRoot());
-            container = createHiveServerContainer(scripts, target, temporaryFolder);
-            base.evaluate();
-            return container;
-        } finally {
-            tearDown();
+            Path temporaryFolder, Statement base) throws Throwable {
+            container = null;
+            File temporaryFile = temporaryFolder.toFile();
+            if (Files.notExists(temporaryFolder)) {
+                temporaryFile = new File(temporaryFolder.toString());
+                temporaryFile.mkdirs();
+                }
+            FileUtil.setPermission(temporaryFile, FsPermission.getDirDefault());
+            try {
+                LOGGER.info("Setting up {} in {}", getName(), temporaryFolder.getRoot());
+                container = createHiveServerContainer(scripts, target, temporaryFolder);
+                base.evaluate();
+                return container;
+            } finally {
+                tearDown();
+            }
         }
-    }
 
     private void tearDown(){
         tearDownContainer();

--- a/src/main/java/com/klarna/hiverunner/StandaloneHiveRunner.java
+++ b/src/main/java/com/klarna/hiverunner/StandaloneHiveRunner.java
@@ -157,23 +157,23 @@ public class StandaloneHiveRunner extends BlockJUnit4ClassRunner {
      * Drives the unit test.
      */
     public HiveShellContainer evaluateStatement(List<? extends Script> scripts, Object target,
-            Path temporaryFolder, Statement base) throws Throwable {
-            container = null;
-            File temporaryFile = temporaryFolder.toFile();
-            if (Files.notExists(temporaryFolder)) {
-                temporaryFile = new File(temporaryFolder.toString());
-                temporaryFile.mkdirs();
-                }
-            FileUtil.setPermission(temporaryFile, FsPermission.getDirDefault());
-            try {
-                LOGGER.info("Setting up {} in {}", getName(), temporaryFolder.getRoot());
-                container = createHiveServerContainer(scripts, target, temporaryFolder);
-                base.evaluate();
-                return container;
-            } finally {
-                tearDown();
+        Path temporaryFolder, Statement base) throws Throwable {
+        container = null;
+        File temporaryFile = temporaryFolder.toFile();
+        if (Files.notExists(temporaryFolder)) {
+            temporaryFile = new File(temporaryFolder.toString());
+            temporaryFile.mkdirs();
             }
+        FileUtil.setPermission(temporaryFile, FsPermission.getDirDefault());
+        try {
+            LOGGER.info("Setting up {} in {}", getName(), temporaryFolder.getRoot());
+            container = createHiveServerContainer(scripts, target, temporaryFolder);
+            base.evaluate();
+            return container;
+        } finally {
+            tearDown();
         }
+    }
 
     private void tearDown(){
         tearDownContainer();


### PR DESCRIPTION
This PR is to fix a bug that appears in Mutant Swarm when the version of HiveRunner is updated to 5.0.0. 

[Mutant Swarm](https://github.com/HotelsDotCom/mutant-swarm) calls HiveRunner once to run the unit test normally, and then will call it multiple times with all the mutated versions of the script under test. But because the temporary folder is deleted at the end of the first run of the unit test we then get errors when we try to rerun it, as the temporary folder no longer exists.

To fix this, I've added some code so that **if** the file does not exists, it is created again.