### PR TITLE
Fix Mutant Swarm bug

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,19 +10,6 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Init Coveralls
-      shell: bash
-      run: |
-          COVERALLS_TOKEN=${{ secrets.COVERALLS_REPO_TOKEN }}
-          if [[ -z "${COVERALLS_TOKEN}" ]];
-          then
-             echo "Coveralls token not available"
-             COVERALLS_SKIP=true
-          else
-             echo "Coveralls token available"
-             COVERALLS_SKIP=false
-          fi
-          echo ::set-env name=COVERALLS_SKIP::${COVERALLS_SKIP}
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,4 +28,4 @@ jobs:
       with:
         java-version: 8
     - name: Run Maven Targets
-      run: mvn package coveralls:report --batch-mode --show-version --activate-profiles coveralls -Dcoveralls.skip=$COVERALLS_SKIP -DrepoToken=${{ secrets.COVERALLS_REPO_TOKEN }}
+      run: mvn package

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,31 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Package and run all tests
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Init Coveralls
+      shell: bash
+      run: |
+          COVERALLS_TOKEN=${{ secrets.COVERALLS_REPO_TOKEN }}
+          if [[ -z "${COVERALLS_TOKEN}" ]];
+          then
+             echo "Coveralls token not available"
+             COVERALLS_SKIP=true
+          else
+             echo "Coveralls token available"
+             COVERALLS_SKIP=false
+          fi
+          echo ::set-env name=COVERALLS_SKIP::${COVERALLS_SKIP}
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: Run Maven Targets
+      run: mvn package coveralls:report --batch-mode --show-version --activate-profiles coveralls -Dcoveralls.skip=$COVERALLS_SKIP -DrepoToken=${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [5.2.2] - TBD
 ### Fixed
-- Fixed bug that appears in [Mutant Swarm](https://github.com/HotelsDotCom/mutant-swarm/pull/18/files) when updating HiveRunner to version 5.2.1.
+- Fixed bug that appears in [Mutant Swarm](https://github.com/HotelsDotCom/mutant-swarm) when updating HiveRunner to version 5.2.1.
 
 ## [5.2.1] - 2020-05-27
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [5.2.2] - TBD
+### Fixed
+- Fixed bug that appears in [Mutant Swarm](https://github.com/HotelsDotCom/mutant-swarm/pull/18/files) when updating HiveRunner to 5.2.1.
+
 ## [5.2.1] - 2020-05-27
 ### Fixed
 - NullPointerException in tearDown of `StandaloneHiveRunner`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [5.2.2] - TBD
 ### Fixed
-- Fixed bug that appears in [Mutant Swarm](https://github.com/HotelsDotCom/mutant-swarm/pull/18/files) when updating HiveRunner to 5.2.1.
+- Fixed bug that appears in [Mutant Swarm](https://github.com/HotelsDotCom/mutant-swarm/pull/18/files) when updating HiveRunner to version 5.2.1.
 
 ## [5.2.1] - 2020-05-27
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.klarna/hiverunner/badge.svg?subject=com.klarna:hiverunner)](https://maven-badges.herokuapp.com/maven-central/com.klarna/hiverunner) [![Build Status](https://travis-ci.org/klarna/HiveRunner.svg?branch=master)](https://travis-ci.org/klarna/HiveRunner) ![build](https://github.com/shermosa/HiveRunner/workflows/build/badge.svg?event=push) ![GitHub license](https://img.shields.io/github/license/klarna/hiverunner.svg)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.klarna/hiverunner/badge.svg?subject=com.klarna:hiverunner)](https://maven-badges.herokuapp.com/maven-central/com.klarna/hiverunner) [![Build Status](https://travis-ci.org/klarna/HiveRunner.svg?branch=master)](https://travis-ci.org/klarna/HiveRunner) ![build](https://github.com/klarna/HiveRunner/workflows/build/badge.svg?event=push) ![GitHub license](https://img.shields.io/github/license/klarna/hiverunner.svg)
 
 ![ScreenShot](/images/HiveRunnerSplash.png)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.klarna/hiverunner/badge.svg?subject=com.klarna:hiverunner)](https://maven-badges.herokuapp.com/maven-central/com.klarna/hiverunner) [![Build Status](https://travis-ci.org/klarna/HiveRunner.svg?branch=master)](https://travis-ci.org/klarna/HiveRunner) ![GitHub license](https://img.shields.io/github/license/klarna/hiverunner.svg)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.klarna/hiverunner/badge.svg?subject=com.klarna:hiverunner)](https://maven-badges.herokuapp.com/maven-central/com.klarna/hiverunner) [![Build Status](https://travis-ci.org/klarna/HiveRunner.svg?branch=master)](https://travis-ci.org/klarna/HiveRunner) ![build](https://github.com/shermosa/HiveRunner/workflows/build/badge.svg?event=push) ![GitHub license](https://img.shields.io/github/license/klarna/hiverunner.svg)
 
 ![ScreenShot](/images/HiveRunnerSplash.png)
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.klarna</groupId>
   <artifactId>hiverunner</artifactId>
-  <version>5.2.1</version>
+  <version>5.2.2-SNAPSHOT</version>
   <name>HiveRunner</name>
   <description>HiveRunner is a unit test framework based on JUnit (4 or 5) that enables TDD development of Hive SQL without the need of any installed dependencies.</description>
   <url>https://github.com/klarna/HiveRunner</url>

--- a/src/main/java/com/klarna/hiverunner/StandaloneHiveRunner.java
+++ b/src/main/java/com/klarna/hiverunner/StandaloneHiveRunner.java
@@ -39,6 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
@@ -156,18 +157,23 @@ public class StandaloneHiveRunner extends BlockJUnit4ClassRunner {
      * Drives the unit test.
      */
     public HiveShellContainer evaluateStatement(List<? extends Script> scripts, Object target,
-        Path temporaryFolder, Statement base) throws Throwable {
-        container = null;
-        FileUtil.setPermission(temporaryFolder.toFile(), FsPermission.getDirDefault());
-        try {
-            LOGGER.info("Setting up {} in {}", getName(), temporaryFolder.getRoot());
-            container = createHiveServerContainer(scripts, target, temporaryFolder);
-            base.evaluate();
-            return container;
-        } finally {
-            tearDown();
+            Path temporaryFolder, Statement base) throws Throwable {
+            container = null;
+            File temporaryFile = temporaryFolder.toFile();
+            if (Files.notExists(temporaryFolder)) {
+                temporaryFile = new File(temporaryFolder.toString());
+                temporaryFile.mkdirs();
+                }
+            FileUtil.setPermission(temporaryFile, FsPermission.getDirDefault());
+            try {
+                LOGGER.info("Setting up {} in {}", getName(), temporaryFolder.getRoot());
+                container = createHiveServerContainer(scripts, target, temporaryFolder);
+                base.evaluate();
+                return container;
+            } finally {
+                tearDown();
+            }
         }
-    }
 
     private void tearDown(){
         tearDownContainer();

--- a/src/main/java/com/klarna/hiverunner/StandaloneHiveRunner.java
+++ b/src/main/java/com/klarna/hiverunner/StandaloneHiveRunner.java
@@ -162,7 +162,7 @@ public class StandaloneHiveRunner extends BlockJUnit4ClassRunner {
         File temporaryFile = temporaryFolder.toFile();
         if (!temporaryFile.exists()) {
             temporaryFile.mkdirs();
-            }
+        }
         FileUtil.setPermission(temporaryFile, FsPermission.getDirDefault());
         try {
             LOGGER.info("Setting up {} in {}", getName(), temporaryFolder.getRoot());

--- a/src/main/java/com/klarna/hiverunner/StandaloneHiveRunner.java
+++ b/src/main/java/com/klarna/hiverunner/StandaloneHiveRunner.java
@@ -157,23 +157,23 @@ public class StandaloneHiveRunner extends BlockJUnit4ClassRunner {
      * Drives the unit test.
      */
     public HiveShellContainer evaluateStatement(List<? extends Script> scripts, Object target,
-            Path temporaryFolder, Statement base) throws Throwable {
-            container = null;
-            File temporaryFile = temporaryFolder.toFile();
-            if (Files.notExists(temporaryFolder)) {
-                temporaryFile = new File(temporaryFolder.toString());
-                temporaryFile.mkdirs();
-                }
-            FileUtil.setPermission(temporaryFile, FsPermission.getDirDefault());
-            try {
-                LOGGER.info("Setting up {} in {}", getName(), temporaryFolder.getRoot());
-                container = createHiveServerContainer(scripts, target, temporaryFolder);
-                base.evaluate();
-                return container;
-            } finally {
-                tearDown();
+        Path temporaryFolder, Statement base) throws Throwable {
+        container = null;
+        File temporaryFile = temporaryFolder.toFile();
+        if (Files.notExists(temporaryFolder)) {
+            temporaryFile = new File(temporaryFolder.toString());
+            temporaryFile.mkdirs();
             }
+        FileUtil.setPermission(temporaryFile, FsPermission.getDirDefault());
+        try {
+            LOGGER.info("Setting up {} in {}", getName(), temporaryFolder.getRoot());
+            container = createHiveServerContainer(scripts, target, temporaryFolder);
+            base.evaluate();
+            return container;
+        } finally {
+            tearDown();
         }
+    }
 
     private void tearDown(){
         tearDownContainer();

--- a/src/main/java/com/klarna/hiverunner/StandaloneHiveRunner.java
+++ b/src/main/java/com/klarna/hiverunner/StandaloneHiveRunner.java
@@ -160,8 +160,7 @@ public class StandaloneHiveRunner extends BlockJUnit4ClassRunner {
         Path temporaryFolder, Statement base) throws Throwable {
         container = null;
         File temporaryFile = temporaryFolder.toFile();
-        if (Files.notExists(temporaryFolder)) {
-            temporaryFile = new File(temporaryFolder.toString());
+        if (!temporaryFile.exists()) {
             temporaryFile.mkdirs();
             }
         FileUtil.setPermission(temporaryFile, FsPermission.getDirDefault());


### PR DESCRIPTION
This PR is to fix a bug that appears in Mutant Swarm when the version of HiveRunner is updated to 5.0.0. 

[Mutant Swarm](https://github.com/HotelsDotCom/mutant-swarm) calls HiveRunner once to run the unit test normally, and then will call it multiple times with all the mutated versions of the script under test. But because the temporary folder is deleted at the end of the first run of the unit test we then get errors when we try to rerun it, as the temporary folder no longer exists.

To fix this, I've added some code so that **if** the file does not exists, it is created again.