### PR TITLE
Increase visibility of HiveRunnerScript and scriptsUnderTest for downstream usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [5.2.3] - TBD
+### Changed
+- Made HiveRunnerScript constructor public.
+- Made `scriptsUnderTest` variable protected so it can be used in [MutantSwarm](https://github.com/HotelsDotCom/mutant-swarm).
+
 ## [5.2.2] - 2020-10-14
 ### Fixed
 - Fixed bug that appears in [Mutant Swarm](https://github.com/HotelsDotCom/mutant-swarm) when updating HiveRunner to version 5.2.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [5.2.3] - TBD
+## [5.3.0] - TBD
 ### Changed
-- Made HiveRunnerScript constructor public.
-- Made `scriptsUnderTest` variable protected so it can be used in [MutantSwarm](https://github.com/HotelsDotCom/mutant-swarm).
+- Made `HiveRunnerScript` constructor public.
+- Made `scriptsUnderTest` variable in `HiveRunnerExtension` protected so it can be used in [MutantSwarm](https://github.com/HotelsDotCom/mutant-swarm).
 
 ## [5.2.2] - 2020-10-14
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.klarna</groupId>
   <artifactId>hiverunner</artifactId>
-  <version>5.2.2</version>
+  <version>5.2.3-SNAPSHOT</version>
   <name>HiveRunner</name>
   <description>HiveRunner is a unit test framework based on JUnit (4 or 5) that enables TDD development of Hive SQL without the need of any installed dependencies.</description>
   <url>https://github.com/klarna/HiveRunner</url>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.klarna</groupId>
   <artifactId>hiverunner</artifactId>
-  <version>5.2.3-SNAPSHOT</version>
+  <version>5.3.0-SNAPSHOT</version>
   <name>HiveRunner</name>
   <description>HiveRunner is a unit test framework based on JUnit (4 or 5) that enables TDD development of Hive SQL without the need of any installed dependencies.</description>
   <url>https://github.com/klarna/HiveRunner</url>

--- a/src/main/java/com/klarna/hiverunner/HiveRunnerExtension.java
+++ b/src/main/java/com/klarna/hiverunner/HiveRunnerExtension.java
@@ -23,6 +23,7 @@ import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -48,7 +49,7 @@ public class HiveRunnerExtension implements AfterEachCallback, TestInstancePostP
   private final HiveRunnerConfig config = new HiveRunnerConfig();
   private Path basedir;
   private HiveShellContainer container;
-  private List<? extends Script> scriptsUnderTest;
+  protected List<Script> scriptsUnderTest = new ArrayList<Script>();
 
   public HiveRunnerExtension() {
     core = new HiveRunnerCore();

--- a/src/main/java/com/klarna/hiverunner/builder/HiveRunnerScript.java
+++ b/src/main/java/com/klarna/hiverunner/builder/HiveRunnerScript.java
@@ -23,7 +23,7 @@ public class HiveRunnerScript implements Script {
   private String sqlText;
   private int index;
   
-  HiveRunnerScript(int index, Path path, String sqlText) {
+  public HiveRunnerScript(int index, Path path, String sqlText) {
     this.index = index;
     this.path = path;
     this.sqlText = sqlText;


### PR DESCRIPTION
In order to migrate [MutantSwarm](https://github.com/HotelsDotCom/mutant-swarm/pull/22/files) to use an extension (Junit5), we need to change the visibility of certain variables.