### PR TITLE
Ignore System.out.close calls so IntelliJ doesn't incorrectly mark tests as terminated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Added `fromScriptPaths` method in `HiveShellBuilder`.
 - Added version `5.7.0` of `junit-vintage-engine`.
 
+### Fixed
+- Successful tests using "SET" no longer marked as "terminated" when run in IntelliJ.
+
 ## [6.0.1] - 2020-09-07
 ### Removed
 - Removed shaded jar that was being produced as a side-effect.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Added version `5.7.0` of `junit-vintage-engine`.
 
 ### Fixed
-- Successful tests using "SET" no longer marked as "terminated" when run in IntelliJ.
+- Successful tests using "SET" no longer marked as "terminated" when run in IntelliJ. See [#94](https://github.com/klarna/HiveRunner/issues/94).
 
 ## [6.0.1] - 2020-09-07
 ### Removed
@@ -37,52 +37,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 - Upgraded Hive version to 3.1.2 (was 2.3.7).
 
-## [5.3.1] - TBD
-### Changed
-- Renamed `HelloAnnotatedHiveRunner` in `com.klarna.hiverunner.examples` to `HelloAnnotatedHiveRunnerTest`.
-- Renamed `HelloHiveRunner` in `com.klarna.hiverunner.examples` to `HelloHiveRunnerTest`.
-- Renamed `InsertTestData` in `com.klarna.hiverunner.examples` to `InsertTestDataTest`.
-- Renamed `SetHiveConfValues` in `com.klarna.hiverunner.examples` to `SetHiveConfValuesTest`.
-- Renamed `HelloAnnotatedHiveRunner` in `com.klarna.hiverunner.examples.junit4` to `HelloAnnotatedHiveRunnerTest`.
-- Renamed `HelloHiveRunner` in `com.klarna.hiverunner.examples.junit4` to `HelloHiveRunnerTest`.
-- Renamed `InsertTestData` in `com.klarna.hiverunner.examples.junit4` to `InsertTestDataTest`.
-- Renamed `SetHiveConfValues` in `com.klarna.hiverunner.examples.junit4` to `SetHiveConfValuesTest`.
-- Updated `surefire-version-plugin` from `2.21.0` to `2.22.0`.
-- Updated `junit.jupiter.version` from `5.6.0` to `5.7.0`.
-
-### Added
-- Added version `5.7.0` of `junit-vintage-engine`.
-
-## [5.3.0] - 2021-01-05
-### Changed
-- Made `HiveRunnerScript` constructor public.
-- Made `scriptsUnderTest` variable in `HiveRunnerExtension` protected so it can be used in [MutantSwarm](https://github.com/HotelsDotCom/mutant-swarm).
-
-### Added
-- Added `getScriptPaths` method in `HiveRunnerCore`.
-- Added `getScriptPaths` method in `HiveRunnerExtension` to be able to access the other method in `HiveRunnerCore` so that it can be used downstream in [MutantSwarm](https://github.com/HotelsDotCom/mutant-swarm).
-- Added `fromScriptPaths` method in `HiveShellBuilder`.
-
-## [5.2.2] - 2020-10-14
-### Fixed
-- Fixed bug that appears in [Mutant Swarm](https://github.com/HotelsDotCom/mutant-swarm) when updating HiveRunner to version 5.2.1.
-
-## [5.2.1] - 2020-05-27
-### Fixed
-- NullPointerException in tearDown of `StandaloneHiveRunner`.
-
-## [5.2.0] - 2020-04-23
-### Changed
-- Upgraded Hive version to 2.3.7 (was 2.3.6) (allows HiveRunner to be used on JDK>=9).
-
-## [5.1.1] - 2020-03-06
-### Changed
-- Upgraded Hive version to 2.3.6 (was 2.3.4).
-
-## [5.1.0] - 2020-01-24
-### Changed
-- Upgraded JUnit Jupiter version to 5.6.0 (was 5.5.1).
-- Depend on `junit-jupiter` instead of `junit-jupiter-api`.
+## [5.x]
+### NOTE
+- Releases from the 5.x (Hive 2) line are not tracked in this CHANGELOG, it only tracks 6.0.0 and above. For changes in 5.x please refer to https://github.com/klarna/HiveRunner/blob/hive-2.x/CHANGELOG.md.
 
 ## [5.0.0] - 2019-09-30
 ### Added

--- a/src/main/java/com/klarna/hiverunner/HiveServerContainer.java
+++ b/src/main/java/com/klarna/hiverunner/HiveServerContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2020 Klarna AB
+ * Copyright (C) 2013-2021 Klarna AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.klarna.hiverunner.builder.Statement;
+import com.klarna.hiverunner.io.IgnoreClosePrintStream;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveVariableSource;
 import org.apache.hadoop.hive.conf.VariableSubstitution;
@@ -35,6 +36,7 @@ import org.apache.hive.service.server.HiveServer2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.PrintStream;
 import java.nio.file.Path;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -116,11 +118,14 @@ public class HiveServerContainer {
     }
 
     public List<Object[]> executeStatement(String hiveql) {
+        //this PrintStream hack can be removed if/when IntelliJ fixes https://youtrack.jetbrains.com/issue/IDEA-120628
+        //see https://github.com/klarna/HiveRunner/issues/94 for more info
+        PrintStream initialPrintStream = System.out;
         try {
+            System.setOut(new IgnoreClosePrintStream(System.out));
             OperationHandle handle = client.executeStatement(sessionHandle, hiveql, new HashMap<>());
             List<Object[]> resultSet = new ArrayList<>();
             if (handle.hasResultSet()) {
-
                 /*
                  * fetchResults will by default return 100 rows per fetch (hive 14). For big result sets we need to continuously fetch the result set until all
                  * rows are fetched.
@@ -146,6 +151,8 @@ public class HiveServerContainer {
         } catch (HiveSQLException e) {
             throw new IllegalArgumentException("Failed to executeQuery Hive query " + hiveql + ": " + e.getMessage(),
                     e);
+        } finally {
+            System.setOut(initialPrintStream);
         }
     }
 

--- a/src/main/java/com/klarna/hiverunner/HiveServerContainer.java
+++ b/src/main/java/com/klarna/hiverunner/HiveServerContainer.java
@@ -118,8 +118,8 @@ public class HiveServerContainer {
     }
 
     public List<Object[]> executeStatement(String hiveql) {
-        //this PrintStream hack can be removed if/when IntelliJ fixes https://youtrack.jetbrains.com/issue/IDEA-120628
-        //see https://github.com/klarna/HiveRunner/issues/94 for more info
+        // This PrintStream hack can be removed if/when IntelliJ fixes https://youtrack.jetbrains.com/issue/IDEA-120628
+        // See https://github.com/klarna/HiveRunner/issues/94 for more info.
         PrintStream initialPrintStream = System.out;
         try {
             System.setOut(new IgnoreClosePrintStream(System.out));

--- a/src/main/java/com/klarna/hiverunner/io/IgnoreClosePrintStream.java
+++ b/src/main/java/com/klarna/hiverunner/io/IgnoreClosePrintStream.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2013-2021 Klarna AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.klarna.hiverunner.io;
+
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+public class IgnoreClosePrintStream extends PrintStream {
+
+    public IgnoreClosePrintStream(OutputStream out) {
+        super(out);
+    }
+
+    @Override
+    public void close() {
+        super.flush();
+    }
+}

--- a/src/test/java/com/klarna/hiverunner/HiveServerContainerTest.java
+++ b/src/test/java/com/klarna/hiverunner/HiveServerContainerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2020 Klarna AB
+ * Copyright (C) 2013-2021 Klarna AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package com.klarna.hiverunner;
 
 import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -51,7 +52,6 @@ public class HiveServerContainerTest {
 
     @Test
     public void testGetBasedir() {
-
         Assert.assertEquals(basedir.getRoot(), container.getBaseDir().getRoot());
     }
 
@@ -67,6 +67,24 @@ public class HiveServerContainerTest {
         List<Object[]> actual = container.executeStatement("show databases");
         Assert.assertEquals(1, actual.size());
         Assert.assertArrayEquals(new Object[] { "default" }, actual.get(0));
+    }
+
+    @Test
+    public void testExecuteStatementOutputStreamReset() {
+        PrintStream initialPrintStream = System.out;
+        container.executeStatement("show databases");
+        Assert.assertEquals(initialPrintStream, System.out);
+    }
+
+    @Test
+    public void testExecuteStatementOutputStreamResetIfException() {
+        PrintStream initialPrintStream = System.out;
+        try {
+            container.executeStatement("use non-existent");
+            Assert.fail("Exception should be thrown");
+        } catch (IllegalArgumentException e) {
+            Assert.assertEquals(initialPrintStream, System.out);
+        }
     }
 
     @Test

--- a/src/test/java/com/klarna/hiverunner/SetTest.java
+++ b/src/test/java/com/klarna/hiverunner/SetTest.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2013-2021 Klarna AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.klarna.hiverunner;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.klarna.hiverunner.annotations.HiveSQL;
+
+import java.nio.file.Paths;
+
+@ExtendWith(HiveRunnerExtension.class)
+public class SetTest {
+
+	@HiveSQL(files = {}, autoStart = true)
+    private HiveShell shell;
+
+	/**
+	 *  This test doesn't actually fail but if it shows up as terminated in IntelliJ (which we can't assert on)
+	 *  then there is a problem.
+	 *
+	 *  See https://github.com/klarna/HiveRunner/issues/94 for more details.
+	 */
+	@Test
+	public void testWithSet() {
+		this.shell.execute(Paths.get("src/test/resources/SetTest/test_with_set.hql"));
+	}
+
+}

--- a/src/test/java/com/klarna/hiverunner/io/IgnoreClosePrintStreamTest.java
+++ b/src/test/java/com/klarna/hiverunner/io/IgnoreClosePrintStreamTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2013-2021 Klarna AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.klarna.hiverunner.io;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.io.PrintStream;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IgnoreClosePrintStreamTest {
+
+    @Mock
+    private PrintStream printStream;
+
+    @Test
+    public void closeIgnored() {
+        IgnoreClosePrintStream ignoreClosePrintStream = new IgnoreClosePrintStream(printStream);
+        ignoreClosePrintStream.close();
+        verify(printStream, never()).close();
+    }
+
+}

--- a/src/test/resources/SetTest/test_with_set.hql
+++ b/src/test/resources/SetTest/test_with_set.hql
@@ -1,0 +1,11 @@
+CREATE DATABASE testdb;
+
+SET hive.exec.dynamic.partition.mode=nonstrict;
+SET hive.exec.dynamic.partition=true;
+
+CREATE EXTERNAL TABLE testdb.test 
+(
+  field1 string, 
+  field2 string
+)
+STORED AS ORC;


### PR DESCRIPTION
Fixes #94 