### PR TITLE
Set HIVE_IN_TEST to true for runner and extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## [6.1.0] - TBD
 ### Changed
 - Upgraded JUnit4 version to 4.13.1 (was 4.12).
+- Set `HIVE_IN_TEST` to true in `StandaloneHiverServerContext` instead of `StandaloneHiveRunner` so checks for non-existent tables are skipped by both the JUnit4 runner and the JUnit5 extension (this removes a lot of log noise from tests using the latter).
 - Made `HiveRunnerScript` constructor public.
 - Made `scriptsUnderTest` variable in `HiveRunnerExtension` protected so it can be used in [MutantSwarm](https://github.com/HotelsDotCom/mutant-swarm).
 - Fixed bug that appears in [Mutant Swarm](https://github.com/HotelsDotCom/mutant-swarm) when updating HiveRunner to version 5.2.1.

--- a/src/main/java/com/klarna/hiverunner/StandaloneHiveRunner.java
+++ b/src/main/java/com/klarna/hiverunner/StandaloneHiveRunner.java
@@ -70,20 +70,6 @@ public class StandaloneHiveRunner extends BlockJUnit4ClassRunner {
 
     public StandaloneHiveRunner(Class<?> clazz) throws InitializationError {
         super(clazz);
-        initializeConfig();
-    }
-
-    /**
-     * Set some properties which make good defaults for test scenarios. These can be overridden
-     * in the individual HiveShell instances though, if needed.
-     */
-    private void initializeConfig() {
-        /**
-         * If hive.in.test=false (default), Hive 3 will assume that the metastore rdbms has already been initialized
-         * with some basic tables and will try to run initial test queries against them.
-         * This results in multiple warning stacktraces if the rdbms has not actually been initialized.
-         */
-        config.getHiveConfSystemOverride().put(HIVE_IN_TEST.getVarname(), "true");
     }
 
     protected HiveRunnerConfig getHiveRunnerConfig() {

--- a/src/main/java/com/klarna/hiverunner/StandaloneHiveServerContext.java
+++ b/src/main/java/com/klarna/hiverunner/StandaloneHiveServerContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2020 Klarna AB
+ * Copyright (C) 2013-2021 Klarna AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_VALIDATE_C
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_VALIDATE_CONSTRAINTS;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_VALIDATE_TABLES;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.SCRATCHDIR;
+import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.HIVE_IN_TEST;
 
 import java.io.File;
 import java.io.IOException;
@@ -124,7 +125,6 @@ public class StandaloneHiveServerContext implements HiveServerContext {
   }
 
   protected void configureMrExecutionEngine(HiveConf conf) {
-
     /*
      * Switch off all optimizers otherwise we didn't manage to contain the map reduction within this JVM.
      */
@@ -207,6 +207,13 @@ public class StandaloneHiveServerContext implements HiveServerContext {
     // No pooling needed. This will save us a lot of threads
     setMetastoreProperty("datanucleus.connectionPoolingType", "None");
 
+    /**
+     * If hive.in.test=false (default), Hive 3 will assume that the metastore rdbms has already been initialized
+     * with some basic tables and will try to run initial test queries against them.
+     * This results in multiple warning stacktraces if the rdbms has not actually been initialized.
+     */
+    setMetastoreProperty(HIVE_IN_TEST.getVarname(), "true");
+    
     setMetastoreProperty(METASTORE_VALIDATE_CONSTRAINTS.varname, "true");
     setMetastoreProperty(METASTORE_VALIDATE_COLUMNS.varname, "true");
     setMetastoreProperty(METASTORE_VALIDATE_TABLES.varname, "true");


### PR DESCRIPTION
Set `HIVE_IN_TEST` to true in `StandaloneHiverServerContext` instead of `StandaloneHiveRunner` so checks for non-existent tables are skipped by both the JUnit4 runner and the JUnit5 extension (this removes a lot of log noise from tests using the latter).